### PR TITLE
 Avoid make install on cran

### DIFF
--- a/r/Rduckhts/configure
+++ b/r/Rduckhts/configure
@@ -269,8 +269,6 @@ fi
 ${MAKE} -j${THREADS} ${HTSLIB_BUILD_TARGETS}
 
 # Avoid "make install" in bundled builds: platform install tools differ and
-# CRAN build sandboxes don't need a system-style installation layout.
-# Stage the minimal runtime/dev artifacts directly under ${HTSLIB_DIR}.
 mkdir -p "${HTSLIB_DIR}/lib" "${HTSLIB_DIR}/include/htslib" "${HTSLIB_DIR}/libexec/htslib"
 cp -f libhts.a "${HTSLIB_DIR}/lib/libhts.a"
 if [ -f "libhts.${SHLIB_EXT}" ]; then


### PR DESCRIPTION
Not clear this is the reason  the installation fails on CRAN for macos : https://cran.r-project.org/web/checks/check_results_Rduckhts.html