### PR TITLE
wasm hangup webr version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 # duckhts 1.1.6.9000 Developement version
 
+- adjust the bundled `Rduckhts` extension metadata trailer for wasm/browser builds to encode `linux_i686_musl` instead of `wasm_mvp` when `r/Rduckhts/configure` detects the Emscripten/webR path
 - harden the bundled `Rduckhts` WebAssembly build path: the package `configure` script now preserves `rwasm`/r-universe `NAME=VALUE` cache overrides, forwards explicit `--build` / `--host` triplets into the vendored `htslib` `./configure`, forwards webR's Emscripten port flags for `zlib`/`bzip2`, seeds wasm-safe Autoconf cache results for `zlib`/`bzip2`/socket probes, injects a tiny Emscripten-only socket compatibility shim for `recv`/`send`/`closesocket`, and disables only the optional `htslib` features that are not available in the stock webR/r-universe wasm toolchain (`libcurl`, `S3`, `GCS`, `lzma`, `plugins`); this fixes the original `ac_cv_func_getrandom=no: command not found` failure and subsequent nested `htslib` cross-compile probe failures without changing non-Wasm targets
 - fix top-level DuckDB wasm packaging without changing `extension-ci-tools`: the CMake wasm build now rebuilds `libduckhts.a` as a fat archive containing vendored `htslib` (and any static archive dependencies CMake can see), so the downstream DuckDB wasm packager no longer wraps a bare extension archive with unresolved `htslib` symbols such as `bcf_readrec`
 

--- a/r/Rduckhts/DESCRIPTION
+++ b/r/Rduckhts/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rduckhts
 Title: 'DuckDB' High Throughput Sequencing File Formats Reader Extension
-Version: 1.1.6.9000-0.0.2
+Version: 1.1.6.9000-0.0.3
 Authors@R: c(
         person(given = "Sounkou Mahamane", family = "Toure",
     email = "sounkoutoure@gmail.com",

--- a/r/Rduckhts/NEWS.md
+++ b/r/Rduckhts/NEWS.md
@@ -1,6 +1,7 @@
 
-# Rduckhts 1.1.6.9000-0.0.2 (Development version)
+# Rduckhts 1.1.6.9000-0.0.3 (Development version)
 
+- Set the bundled extension metadata platform to `linux_i686_musl` for the Emscripten/webR path in `configure`, matching the platform value you are using for browser-side loading tests.
 - Fix Wasm package builds under `rwasm` / r-universe: the package `configure` script now preserves injected `NAME=VALUE` cache overrides, forwards explicit `--build` / `--host` triplets into the vendored `htslib` `./configure`, forwards webR's Emscripten port flags for `zlib`/`bzip2`, seeds wasm-safe Autoconf cache results for `zlib`/`bzip2`/socket probes, injects a tiny Emscripten-only socket compatibility shim for `recv`/`send`/`closesocket`, and disables only the optional `htslib` features that are not available in the stock webR/r-universe wasm toolchain (`libcurl`, `S3`, `GCS`, `lzma`, plugins); this fixes the original `ac_cv_func_getrandom=no: command not found` failure and the subsequent nested `htslib` cross-compile probe failures without changing native configure behavior.
 - Fix bundled extension wasm artifacts: the upstream CMake wasm build now rebuilds `libduckhts.a` as a fat archive containing vendored `htslib` (and any static archive dependencies CMake can see), so DuckDB wasm packaging no longer depends on `extension-ci-tools` changes just to avoid unresolved symbols such as `bcf_readrec` at `LOAD`.
 

--- a/r/Rduckhts/configure
+++ b/r/Rduckhts/configure
@@ -119,7 +119,7 @@ OS_NAME=`uname -s`
 ARCH_NAME=`uname -m`
 DUCKDB_PLATFORM=""
 if [ "${WASM_BUILD}" = "yes" ]; then
-  DUCKDB_PLATFORM="wasm_mvp"
+  DUCKDB_PLATFORM="linux_i686_musl"
 fi
 if [ -z "${DUCKDB_PLATFORM}" ]; then
   case "${OS_NAME}" in


### PR DESCRIPTION
use linux_i686_musl for webr duckdb build environment
maybe this will fail