### PR TITLE
CI: make private C contracts build-identity and platform safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,14 +143,15 @@ bench-simd-kernels:
 # VEP-116 differing-region compatibility view.  This deliberately has no
 # DuckDB dependency so sanitizers and alternate C compilers can exercise it.
 test-duckvep-allele:
-	mkdir -p build
+	@tmp=$$(mktemp -d "$${TMPDIR:-/tmp}/duckhts-duckvep-allele.XXXXXX"); \
+	trap 'rm -rf "$$tmp"' EXIT HUP INT TERM; \
 	$(CC) -std=c99 -O2 -Wall -Wextra -Wpedantic -Werror \
 		-Wconversion -Wsign-conversion -Wshadow -Wstrict-prototypes \
 		-I src/duckvep \
 		src/duckvep/duckvep_allele.c \
 		test/duckvep/test_duckvep_allele.c \
-		-o build/test_duckvep_allele
-	./build/test_duckvep_allele
+		-o "$$tmp/test_duckvep_allele"; \
+	"$$tmp/test_duckvep_allele"
 
 test-duckvep-model:
 	Rscript test/duckvep_model.R

--- a/r/Rduckhts/inst/duckhts_extension/duckvep/duckvep_allele.h
+++ b/r/Rduckhts/inst/duckhts_extension/duckvep/duckvep_allele.h
@@ -12,7 +12,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
 #define DUCKVEP_INTERNAL __attribute__((__visibility__("hidden")))
 #else
 #define DUCKVEP_INTERNAL

--- a/src/duckvep/duckvep_allele.h
+++ b/src/duckvep/duckvep_allele.h
@@ -12,7 +12,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(_WIN32)
 #define DUCKVEP_INTERNAL __attribute__((__visibility__("hidden")))
 #else
 #define DUCKVEP_INTERNAL


### PR DESCRIPTION
## Summary

- build and run the private DuckVEP allele test from a fresh temporary directory, then remove it
- suppress ELF-only hidden-visibility attributes on Windows/PE builds

## Root causes

The x86 distribution workflow first linked `build/test_duckvep_allele` inside a root-owned container and later ran `make test_release` as the host runner. The second linker invocation could not truncate that executable.

MinGW defines `__GNUC__` but does not support ELF `visibility("hidden")`; strict standalone compilation promoted the ignored-attribute warning to an error.

## Validation

- `make test-duckvep-allele` twice consecutively
- strict `_WIN32`-defined standalone C build and execution
- `make test_release` (28 SQL suites)
- `git diff --check`