### PR TITLE
Start the 1.4.0.9000 development cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,14 @@ Additional R package rules:
 - All R changes must maintain CRAN compatibility.
 - A new public function is incomplete until its C source is wired through both the extension build and the R package build on Unix and Windows.
 
+### Version Bump Workflow
+- The authoritative extension version is `version:` in the root `description.yml`.
+- The authoritative R package version is `Version:` in `r/Rduckhts/DESCRIPTION`; keep the DuckHTS version before the hyphen and the R packaging revision after it.
+- After releasing `X.Y.Z` to both CRAN and the DuckDB community extension repository, start the next development cycle by changing only those two declarations: `X.Y.Z` -> `X.Y.Z.9000` and `X.Y.Z-A` -> `X.Y.Z.9000-A`.
+- For a release, perform the inverse transformation while retaining the current R packaging revision `A`.
+- Do not hand-edit `configure/extension_version.txt`, rendered README/catalog files, or the local `community-extensions/` descriptor for a version-only bump. Normal configure, bootstrap, and catalog rendering carry the authoritative versions forward.
+- A version-only development-cycle bump does not add empty `NEWS.md` sections; changelog entries belong to actual user-visible changes and release finalization.
+
 ## Testing and Fixtures
 Every public feature needs two levels of testing unless the change is docs-only:
 1. SQL conformance in `test/sql/` — schema, semantics, region/index behavior.

--- a/description.yml
+++ b/description.yml
@@ -1,5 +1,5 @@
 name: duckhts
-version: 1.4.0
+version: 1.4.0.9000
 description: DuckDB extension for reading HTS file formats via htslib
 license: MIT
 excluded_platforms: windows_amd64;windows_arm64

--- a/r/Rduckhts/DESCRIPTION
+++ b/r/Rduckhts/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rduckhts
 Title: 'DuckDB' High Throughput Sequencing File Formats Reader Extension
-Version: 1.4.0-0.1.0
+Version: 1.4.0.9000-0.1.0
 Authors@R: c(
     person(given = "Sounkou Mahamane", family = "Toure",
     email = "sounkoutoure@gmail.com",


### PR DESCRIPTION
Start the post-1.4.0 development cycle by updating the two authoritative declarations:

- DuckHTS extension: 1.4.0.9000 in description.yml
- Bundled R package: 1.4.0.9000-0.1.0 in r/Rduckhts/DESCRIPTION

Record the exact release/development transformation in AGENTS.md so future bumps change only those sources. Generated metadata, rendered catalogs, README output, configure caches, and empty changelog stubs are explicitly excluded.

Validation: the R DESCRIPTION parses with the expected version, and git diff --check passes.