### PR TITLE
Require Codex review before merging pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,3 +217,9 @@ Follow `STYLE.md`. In particular: keep ownership explicit, return errors instead
 aborting DuckDB, bound input-driven allocation, avoid fake object systems and future-only
 interfaces, write R as R, preserve SQL composability, and make no benchmark claim beyond a
 measured documented workload.
+
+Do not use bare `boundary` as an explanation. Name the concrete axis and location: for
+example an exon–intron junction, CDS start or end, transcript endpoint, VCF anchor-removal
+case, reference/alternate differing-region edge, allocation limit, DuckDB/C ownership
+interface, or DuckDB vector edge. If a genuinely generic boundary is needed, define the
+term locally before using it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,15 @@ recorded workload. Do not claim "no regression" when workloads or environments d
 If no checked-in benchmark exercises the changed path, state that explicitly in the
 section, cite the nearest rendered baseline, and say what measurement is still missing.
 
+### Pull Request Codex Review — Mandatory
+
+Every pull request must receive a Codex review of its current head commit before merge.
+After the ready-for-review PR is pushed, comment `@codex review` and wait for the Codex
+response. Address every actionable finding, push the fix, and request another review;
+repeat until Codex reports no major issue on the current head. Do not merge merely because
+GitHub marks the branch mergeable or because CI passes. Record the reviewed commit in the
+handoff when the review response names it.
+
 Useful validation commands:
 
 ```bash


### PR DESCRIPTION
## What changed

Adds a mandatory pull-request gate to `AGENTS.md`:

- request Codex review with `@codex review` on every ready PR;
- wait for a response covering the current head commit;
- address actionable findings and re-request review after every fix;
- merge only after Codex reports no major issue on the current head.

It also forbids bare `boundary` language: agents must name the concrete genomic,
representation, memory, ownership, or vector edge meant in that context.

This prevents GitHub's mergeable state or passing CI from being mistaken for completed code review.

## Performance

This is an agent-workflow-only change; it modifies no C, R, SQL, generated artifact, test, or build path, so no executable workload changes relative to merge commit `3a44c52`. The nearest checked-in rendered measurements are in [`benchmarks/duckvep_throughput.md`](benchmarks/duckvep_throughput.md) at source revision `7dd90ce8`: on one i5-13500 thread with the 644,427-transcript Ensembl 116 GRCh38 model, the compact sorted-GIAB workload processed 100,957 inputs and 1,174,245 output rows in 0.119 s median (848,378 variants/s), while the 200,000-input coding-mixed workload emitted 5,756,720 rows in 1.561 s median (128,123 variants/s). No new timing was run because the executable is byte-for-byte outside this PR's one-file documentation diff.

## Validation

- `git diff --check`
- reviewed the committed diff: the Codex gate and context-specific terminology rule in
  `AGENTS.md`
