### PR TITLE
Execute BigWig README example

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -131,10 +131,9 @@ ranges. `blocks_per_iteration` controls indexed block batching inside a worker,
 not the number of workers.
 
 This query reads a real 100 kb slice of the UCSC GRCh38 phyloP 100-way track
-rather than converting it to an intermediate text file. It is shown without
-running it during README rendering so documentation builds remain offline:
+rather than converting it to an intermediate text file:
 
-```sql
+```{sql eval=TRUE, collapse=FALSE, comment=""}
 SELECT count(*) AS stored_intervals,
        min(VALUE)::DOUBLE AS minimum,
        max(VALUE)::DOUBLE AS maximum

--- a/README.md
+++ b/README.md
@@ -348,9 +348,7 @@ controls indexed block batching inside a worker, not the number of
 workers.
 
 This query reads a real 100 kb slice of the UCSC GRCh38 phyloP 100-way
-track rather than converting it to an intermediate text file. It is
-shown without running it during README rendering so documentation builds
-remain offline:
+track rather than converting it to an intermediate text file:
 
 ``` sql
 SELECT count(*) AS stored_intervals,
@@ -361,6 +359,13 @@ FROM read_bigwig(
   region := 'chr22:20000000-20099999'
 );
 ```
+
+    ┌──────────────────┬─────────────────────┬──────────────────┐
+    │ stored_intervals │       minimum       │     maximum      │
+    │      int64       │       double        │      double      │
+    ├──────────────────┼─────────────────────┼──────────────────┤
+    │            96783 │ -10.786999702453613 │ 9.60200023651123 │
+    └──────────────────┴─────────────────────┴──────────────────┘
 
 ### Variant normalization
 


### PR DESCRIPTION
## Summary

- execute the real UCSC GRCh38 phyloP 100-way BigWig query while rendering the root README
- commit the measured 100 kb result instead of showing an unevaluated query

## Validation

- `Rscript -e "rmarkdown::render('README.Rmd', output_format = 'github_document')"`
- `git diff --check`
- rendered result: 96,783 stored intervals, minimum -10.786999702453613, maximum 9.60200023651123

## Performance

The changed files are documentation only and do not alter the BigWig reader hot path, so the benchmark was not rerun. The nearest checked-in measurement is `benchmarks/benchmark_bigwig_reader.md` at source revision `669d2c4d9b91`: a local 10 Mb UCSC hg38 phyloP 100-way slice containing 9,314,560 stored intervals. Full-scan aggregation recorded median 0.994 seconds with one thread and 0.993 seconds with four threads; 20 indexed ranges emitted 4,656,131 intervals in median 0.498 seconds with one thread and 0.130 seconds with four threads. Remote latency for the README query is intentionally outside that local-reader benchmark.