### PR TITLE
Finalize Rduckhts 1.5.0 CRAN portability

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # DuckHTS Extension News
 
 # duckhts 1.5.0
+- bounds-check htslib's in-place `BQ`/`ZQ` tag rename before writing the tag
+  name, avoiding GCC 11's zero-size-region diagnostic while preserving BAQ
+  behavior
 - clarify the public DuckVEP model contract before release: the native kernel is
   transcript-source-neutral, while the supplied builder compiles the Ensembl core set;
   transcript-to-genome sequence corrections and circular-origin geometry remain

--- a/r/Rduckhts/NEWS.md
+++ b/r/Rduckhts/NEWS.md
@@ -1,5 +1,9 @@
 
 # Rduckhts 1.5.0-0.1.0
+- make the in-memory downstream htslib consumer test compatible with both the
+  original and argument-capable `Rtinycc::tcc_call_symbol()` APIs, and bundle
+  bounds-checked BAQ tag renaming so GCC 11 package builds do not emit the
+  former zero-size-region warning
 - clarify the bundled DuckVEP catalog and README: the resident kernel is
   transcript-source-neutral, the package builder currently compiles the Ensembl core set,
   and transcript-to-genome sequence corrections, circular-origin geometry, implicit path

--- a/r/Rduckhts/cran-comments.md
+++ b/r/Rduckhts/cran-comments.md
@@ -1,10 +1,19 @@
 ## Submission
 
 This submission updates the bundled 'duckhts' DuckDB extension in Rduckhts
-(1.4.0 -> 1.5.0). The release adds the DuckVEP consequence/HGVS surface,
-BigWig reading, downstream htslib linking metadata, reader and normalization
-extensions, and correctness fixes. Full details are in `NEWS.md`. There is no
-user-facing API breakage.
+(1.4.0 -> 1.5.0). Since the previous CRAN release, it:
+
+- adds the DuckVEP consequence/HGVS relation, Ensembl model builder,
+  regulatory/motif, structural-variant, breakend, and NMD support, with
+  VEP-116 compatibility fixes;
+- adds BigWig reading through the package's htslib transport and region
+  semantics;
+- updates bundled htslib to 1.24 and exposes versioned downstream linking
+  metadata; and
+- extends BCF parsing, normalization, FASTQ projection/QC, cross-platform
+  package tests, wasm tests, and differential validation.
+
+Full details are in `NEWS.md`. There is no user-facing API breakage.
 
 ## Test environments
 

--- a/r/Rduckhts/inst/duckhts_extension/htslib/realn.c
+++ b/r/Rduckhts/inst/duckhts_extension/htslib/realn.c
@@ -104,6 +104,19 @@ static int realn_check_tag(const uint8_t *tg, enum htsLogLevel severity,
     return 0;
 }
 
+static int realn_rename_tag(bam1_t *b, const uint8_t *value, uint8_t first_char) {
+    size_t value_offset;
+
+    if (!b->data || b->l_data < 3 || value < b->data + 3 ||
+        value > b->data + b->l_data)
+        return -1;
+
+    value_offset = (size_t) (value - b->data);
+    b->data[value_offset - 3] = first_char;
+
+    return 0;
+}
+
 int sam_prob_realn(bam1_t *b, const char *ref, hts_pos_t ref_len, int flag) {
     int k, bw, y, yb, ye, xb, xe, fix_bq = 0, apply_baq = flag & BAQ_APPLY,
         extend_baq = flag & BAQ_EXTEND, redo_baq = flag & BAQ_REDO;
@@ -168,11 +181,13 @@ int sam_prob_realn(bam1_t *b, const char *ref, hts_pos_t ref_len, int flag) {
         if (bq && apply_baq) { // then convert BQ to ZQ
             for (i = 0; i < c->l_qseq; ++i)
                 qual[i] = qual[i] + 64 < bq[i]? 0 : qual[i] - ((int)bq[i] - 64);
-            *(bq - 3) = 'Z';
+            if (realn_rename_tag(b, bq, 'Z') < 0)
+                return -4;
         } else if (zq && !apply_baq) { // then convert ZQ to BQ
             for (i = 0; i < c->l_qseq; ++i)
                 qual[i] += (int)zq[i] - 64;
-            *(zq - 3) = 'B';
+            if (realn_rename_tag(b, zq, 'B') < 0)
+                return -4;
         }
         return 0;
     }

--- a/r/Rduckhts/inst/tinytest/test_htslib_contract.R
+++ b/r/Rduckhts/inst/tinytest/test_htslib_contract.R
@@ -67,10 +67,30 @@ test_htslib_contract <- function() {
     return(invisible(NULL))
   }
 
+  fixture <- function(name) {
+    system.file("extdata", name, package = "Rduckhts", mustWork = TRUE)
+  }
+  c_string <- function(value) {
+    encodeString(value, quote = "\"")
+  }
   consumer_code <- paste(c(
     "#include <htslib/hts.h>",
     "#include <htslib/sam.h>",
     "#include <htslib/vcf.h>",
+    paste0(
+      "static const char expected_version[] = ",
+      c_string(config$htslib_version),
+      ";"
+    ),
+    paste0("static const char bam_path[] = ", c_string(fixture("range.bam")), ";"),
+    paste0("static const char cram_path[] = ", c_string(fixture("range.cram")), ";"),
+    paste0("static const char reference_path[] = ", c_string(fixture("ce.fa")), ";"),
+    paste0("static const char bcf_path[] = ", c_string(fixture("vcf_file.bcf")), ";"),
+    paste0(
+      "static const char vcf_path[] = ",
+      c_string(fixture("test_vep_tidy.vcf")),
+      ";"
+    ),
     "static int text_equal(const char *left, const char *right) {",
     "    while (*left && *left == *right) { left++; right++; }",
     "    return *left == *right;",
@@ -96,13 +116,12 @@ test_htslib_contract <- function() {
     "    bcf_destroy(record); bcf_hdr_destroy(header); bcf_close(file);",
     "    return result;",
     "}",
-    "void check_consumer(char **version, char **bam, char **cram, char **reference,",
-    "                    char **bcf, char **vcf, int *status) {",
-    "    *status = 0;",
-    "    if (!text_equal(hts_version(), *version)) { *status = 10; return; }",
-    "    if (!alignment_ok(*bam, NULL)) { *status = 11; return; }",
-    "    if (!alignment_ok(*cram, *reference)) { *status = 12; return; }",
-    "    if (!variant_ok(*bcf) || !variant_ok(*vcf)) *status = 13;",
+    "int check_consumer(void) {",
+    "    if (!text_equal(hts_version(), expected_version)) return 10;",
+    "    if (!alignment_ok(bam_path, NULL)) return 11;",
+    "    if (!alignment_ok(cram_path, reference_path)) return 12;",
+    "    if (!variant_ok(bcf_path) || !variant_ok(vcf_path)) return 13;",
+    "    return 0;",
     "}"
   ), collapse = "\n")
 
@@ -152,21 +171,12 @@ test_htslib_contract <- function() {
   expect_identical(relocate_status, 0L)
   if (relocate_status != 0L) return(invisible(NULL))
 
-  fixture <- function(name) {
-    system.file("extdata", name, package = "Rduckhts", mustWork = TRUE)
-  }
   result <- Rtinycc::tcc_call_symbol(
     state,
     "check_consumer",
-    config$htslib_version,
-    fixture("range.bam"),
-    fixture("range.cram"),
-    fixture("ce.fa"),
-    fixture("vcf_file.bcf"),
-    fixture("test_vep_tidy.vcf"),
-    as.integer(0)
+    return = "int"
   )
-  expect_identical(result[[7L]], 0L)
+  expect_identical(result, 0L)
 }
 
 test_htslib_contract()

--- a/third_party/htslib/realn.c
+++ b/third_party/htslib/realn.c
@@ -104,6 +104,19 @@ static int realn_check_tag(const uint8_t *tg, enum htsLogLevel severity,
     return 0;
 }
 
+static int realn_rename_tag(bam1_t *b, const uint8_t *value, uint8_t first_char) {
+    size_t value_offset;
+
+    if (!b->data || b->l_data < 3 || value < b->data + 3 ||
+        value > b->data + b->l_data)
+        return -1;
+
+    value_offset = (size_t) (value - b->data);
+    b->data[value_offset - 3] = first_char;
+
+    return 0;
+}
+
 int sam_prob_realn(bam1_t *b, const char *ref, hts_pos_t ref_len, int flag) {
     int k, bw, y, yb, ye, xb, xe, fix_bq = 0, apply_baq = flag & BAQ_APPLY,
         extend_baq = flag & BAQ_EXTEND, redo_baq = flag & BAQ_REDO;
@@ -168,11 +181,13 @@ int sam_prob_realn(bam1_t *b, const char *ref, hts_pos_t ref_len, int flag) {
         if (bq && apply_baq) { // then convert BQ to ZQ
             for (i = 0; i < c->l_qseq; ++i)
                 qual[i] = qual[i] + 64 < bq[i]? 0 : qual[i] - ((int)bq[i] - 64);
-            *(bq - 3) = 'Z';
+            if (realn_rename_tag(b, bq, 'Z') < 0)
+                return -4;
         } else if (zq && !apply_baq) { // then convert ZQ to BQ
             for (i = 0; i < c->l_qseq; ++i)
                 qual[i] += (int)zq[i] - 64;
-            *(zq - 3) = 'B';
+            if (realn_rename_tag(b, zq, 'B') < 0)
+                return -4;
         }
         return 0;
     }

--- a/third_party/patches/htslib/0002-bounds-check-baq-tag-rename.patch
+++ b/third_party/patches/htslib/0002-bounds-check-baq-tag-rename.patch
@@ -1,0 +1,40 @@
+diff --git a/realn.c b/realn.c
+index 0127e41..06dcd47 100644
+--- a/realn.c
++++ b/realn.c
+@@ -104,6 +104,19 @@ static int realn_check_tag(const uint8_t *tg, enum htsLogLevel severity,
+     return 0;
+ }
+
++static int realn_rename_tag(bam1_t *b, const uint8_t *value, uint8_t first_char) {
++    size_t value_offset;
++
++    if (!b->data || b->l_data < 3 || value < b->data + 3 ||
++        value > b->data + b->l_data)
++        return -1;
++
++    value_offset = (size_t) (value - b->data);
++    b->data[value_offset - 3] = first_char;
++
++    return 0;
++}
++
+ int sam_prob_realn(bam1_t *b, const char *ref, hts_pos_t ref_len, int flag) {
+     int k, bw, y, yb, ye, xb, xe, fix_bq = 0, apply_baq = flag & BAQ_APPLY,
+         extend_baq = flag & BAQ_EXTEND, redo_baq = flag & BAQ_REDO;
+@@ -168,11 +181,13 @@ int sam_prob_realn(bam1_t *b, const char *ref, hts_pos_t ref_len, int flag) {
+         if (bq && apply_baq) { // then convert BQ to ZQ
+             for (i = 0; i < c->l_qseq; ++i)
+                 qual[i] = qual[i] + 64 < bq[i]? 0 : qual[i] - ((int)bq[i] - 64);
+-            *(bq - 3) = 'Z';
++            if (realn_rename_tag(b, bq, 'Z') < 0)
++                return -4;
+         } else if (zq && !apply_baq) { // then convert ZQ to BQ
+             for (i = 0; i < c->l_qseq; ++i)
+                 qual[i] += (int)zq[i] - 64;
+-            *(zq - 3) = 'B';
++            if (realn_rename_tag(b, zq, 'B') < 0)
++                return -4;
+         }
+         return 0;
+     }


### PR DESCRIPTION
## Summary

- make the in-memory downstream htslib consumer test work with both the original and argument-capable `Rtinycc::tcc_call_symbol()` APIs
- vendor a bounds-checked htslib BAQ tag rename through the pinned patch flow, removing the GCC 11 zero-size-region diagnostic
- add a concise CRAN submission summary for the complete Rduckhts 1.5.0 update

## Validation

- `Rscript bootstrap.R /root/duckhts`
- `THREADS=4 make test`: 2,105 assertions passed
- `R CMD check --as-cran Rduckhts_1.5.0-0.1.0.tar.gz`: 0 errors, 0 warnings, 1 explained account-history NOTE
- pinned htslib 1.24 vendoring regenerated from its checksum-verified archive and reproduced the bundled package source byte-for-byte
- both root and package README files rendered from their `.Rmd` sources; no README source or rendered-content change remains in this PR

## Performance

No checked-in benchmark exercises the changed htslib BAQ tag-rename error path or the Rtinycc package-contract test, and neither change touches a measured DuckHTS reader or annotation hot path. The nearest checked-in release baseline is `benchmarks/duckvep_throughput.md`: revision `0eb1b440`, Ensembl 116 GRCh38 plus all 1,383,580 resident regulation/motif features, 4,095,611 GIAB HG002 alleles and 47,835,851 output rows. The fused rich-plus-HGVS public relation recorded a 23.640-second median on one pinned physical core (173,249 alleles/s) and 6.602 seconds on four pinned physical cores (620,359 alleles/s). A BAQ-specific performance measurement is still absent because Rduckhts does not expose this htslib tag-rename path as a benchmarked operation.
