### PR TITLE
ci: enforce strict CRAN-style R builds

### DIFF
--- a/.github/workflows/cran-check.yml
+++ b/.github/workflows/cran-check.yml
@@ -34,6 +34,23 @@ jobs:
           DUCKHTS_FEDORA_CONTAINER: 1
         run: bash scripts/check_cran_fedora.sh
 
+  fedora-clang:
+    runs-on: ubuntu-latest
+    name: Fedora 44 Clang 22 (CRAN-like)
+    container:
+      # Pinned Fedora 44 image; see scripts/check_cran_fedora.sh for the
+      # compiler and CRAN-configuration receipt.
+      image: fedora@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and check with warnings promoted to errors
+        env:
+          DUCKHTS_FEDORA_CONTAINER: 1
+          DUCKHTS_FEDORA_PROFILE: clang
+        run: bash scripts/check_cran_fedora_clang.sh
+
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
@@ -79,5 +96,5 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
-          error-on: '"error"'
+          error-on: '"warning"'
           working-directory: r/Rduckhts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,12 @@ endif()
 ###
 project(${EXTENSION_NAME} LANGUAGES C)
 
+# Native builds must fail on diagnostics from DuckHTS and bundled libBigWig.
+# Vendored htslib is built independently with its upstream warning policy.
+option(DUCKHTS_STRICT_WARNINGS
+       "Treat DuckHTS native compiler warnings as errors"
+       ON)
+
 # Create Extension library
 set(EXTENSION_SOURCES
         src/duckhts.c
@@ -152,14 +158,30 @@ endif()
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(VISIBILITY_INLINES_HIDDEN ON)
-# Strip symbols on Linux (not supported by AppleClang)
-if(NOT APPLE)
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+# Strip native shared libraries on Linux. This is a linker option: passing it
+# through CMAKE_<LANG>_FLAGS_RELEASE makes Clang diagnose an unused compile
+# argument when the native warning gate uses -Werror.
+if(NOT APPLE AND NOT DUCKDB_WASM_EXTENSION)
+    set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -s")
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
-    target_compile_options(${EXTENSION_NAME} PRIVATE -Wpedantic)
+    target_compile_options(${EXTENSION_NAME} PRIVATE
+        -Wall
+        -Wextra
+        -Wpedantic
+        -Wformat=2
+        -Wstrict-prototypes)
+    if(DUCKHTS_STRICT_WARNINGS AND NOT EMSCRIPTEN)
+        target_compile_options(${EXTENSION_NAME} PRIVATE -Werror)
+    endif()
+    # These translation units are pinned upstream implementations. Keep their
+    # diagnostic policy independent from DuckHTS-owned sources, as with the
+    # separately built htslib dependency.
+    set_source_files_properties(
+        src/bcftools_filter.c
+        third_party/cgranges/cgranges.c
+        PROPERTIES COMPILE_OPTIONS "-w")
 endif()
 
 # Include own headers
@@ -171,8 +193,9 @@ target_include_directories(${EXTENSION_NAME} PRIVATE third_party/libBigWig)
 target_include_directories(${EXTENSION_NAME} PRIVATE third_party/variantkey/include)
 target_compile_definitions(${EXTENSION_NAME} PRIVATE NOCURL=1)
 
-# Include DuckDB C API headers
-target_include_directories(${EXTENSION_NAME} PRIVATE duckdb_capi)
+# DuckDB's fetched C API is an external header surface. Its historical
+# no-prototype declarations are not DuckHTS diagnostics.
+target_include_directories(${EXTENSION_NAME} SYSTEM PRIVATE duckdb_capi)
 
 # ---- htslib ----
 # Build vendored htslib using its own configure + make.  CMake drives the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # DuckHTS Extension News
 
 # duckhts 1.5.0.9000
+- make native DuckHTS builds promote their compiler diagnostics to errors by
+  default, while keeping pinned upstream implementation diagnostics isolated
+- initialize the `bcftools_norm_row` shared out-of-memory cleanup count before
+  any allocation can fail, avoiding an indeterminate cleanup-loop bound
 - patch pinned libBigWig's `bwCleanup` definition to match its public
   `bwCleanup(void)` declaration, keeping Clang strict-prototype builds
   warning-clean

--- a/r/Rduckhts/Makefile
+++ b/r/Rduckhts/Makefile
@@ -48,9 +48,9 @@ clean:
 	rm -f $(PKG_NAME)_*.tar.gz
 	rm -rf $(PKG_NAME).Rcheck/
 	rm -f src/*.o src/*.so
-	cd inst/duckhts_extension/htslib && make clean 2>/dev/null || true
-	rm -f inst/duckhts_extension/config.log inst/duckhts_extension/config.status
-	rm -f inst/duckhts_extension/htslib/libhts.a inst/duckhts_extension/htslib/libhts.so* inst/duckhts_extension/htslib/htslib.pc
+	# Do not run htslib's clean target here: inst/duckhts_extension is bundled
+	# package source, and htslib clean can remove tracked fixtures. R CMD check
+	# configures and compiles only its extracted package copy.
 	rm -f inst/extdata/*.duckdb_extension*
 	rm -f inst/extdata/*.tmp
 	rm -f inst/extdata/*.raw

--- a/r/Rduckhts/NEWS.md
+++ b/r/Rduckhts/NEWS.md
@@ -1,5 +1,9 @@
 
 # Rduckhts 1.5.0.9000-0.1.0
+- make bundled-extension compilation promote DuckHTS and libBigWig diagnostics
+  to errors by default, including CRAN-like Fedora Clang builds
+- bundle the `bcftools_norm_row` out-of-memory cleanup correction so a failed
+  internal allocation cannot use an indeterminate allele-buffer count
 - bundle the libBigWig strict-prototype correction so macOS Clang package
   installation no longer warns about the `bwCleanup` definition
 - bundle VEP-116-compatible gVCF event dispatch: expanded `<NON_REF>`, bare

--- a/r/Rduckhts/configure
+++ b/r/Rduckhts/configure
@@ -22,13 +22,21 @@ for arg in "$@"; do
 done
 
 MAKE=`"${R_HOME}/bin/R" CMD config MAKE`
-CC=`"${R_HOME}/bin/R" CMD config CC | cut -f1 -d' '`
+R_CONFIG_CC=`"${R_HOME}/bin/R" CMD config CC | cut -f1 -d' '`
+# The Fedora-Clang CRAN-like job selects Clang without changing R's Makeconf.
+# Ordinary builds retain the compiler configured for R.
+CC="${DUCKHTS_CC:-${R_CONFIG_CC}}"
 AR=`"${R_HOME}/bin/R" CMD config AR`
 RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB`
 R_CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 R_CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 R_CPICFLAGS=`"${R_HOME}/bin/R" CMD config CPICFLAGS`
 R_LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
+if [ "${DUCKHTS_LDFLAGS+x}" = x ]; then
+  BASE_LDFLAGS="${DUCKHTS_LDFLAGS}"
+else
+  BASE_LDFLAGS="${R_LDFLAGS}"
+fi
 
 WASM_BUILD=no
 if echo "${CC}" | grep -q "emcc" || echo "${CC}" | grep -q "wasm"; then
@@ -67,9 +75,12 @@ if [ ! -f "${DUCKDB_CAPI_HEADER}" ]; then
   exit 1
 fi
 
-CFLAGS="${R_CFLAGS} ${R_CPICFLAGS} -O2 -fPIC -D_FILE_OFFSET_BITS=64"
+# A profile that intentionally selects another compiler (for example the
+# Fedora-Clang CRAN-like runner) can supply that compiler's base flags.
+BASE_CFLAGS="${DUCKHTS_CFLAGS:-${R_CFLAGS}}"
+CFLAGS="${BASE_CFLAGS} ${R_CPICFLAGS} -O2 -fPIC -D_FILE_OFFSET_BITS=64"
 CPPFLAGS="${R_CPPFLAGS} -DNDEBUG"
-LDFLAGS="${R_LDFLAGS}"
+LDFLAGS="${BASE_LDFLAGS}"
 EM_PORT_FLAGS=""
 
 if [ "${WASM_BUILD}" = "yes" ]; then
@@ -86,9 +97,29 @@ fi
 # vendored dependency; DuckHTS sources continue to use R's compiler mode.
 HTSLIB_CFLAGS="${CFLAGS} -std=gnu17"
 
-# Keep stricter diagnostics on DuckHTS extension sources without applying them
-# to the vendored htslib build.
-EXT_CFLAGS="${CFLAGS} -Wpedantic -DNOCURL=1"
+# Apply one warning-as-error policy to DuckHTS and bundled libBigWig sources.
+# htslib retains its upstream warning policy and GNU17 override above: it is a
+# separately built dependency, not a reason to weaken this package gate.
+DUCKHTS_STRICT_WARNINGS="${DUCKHTS_STRICT_WARNINGS:-1}"
+case "${DUCKHTS_STRICT_WARNINGS}" in
+  0|1) ;;
+  *)
+    echo "ERROR: DUCKHTS_STRICT_WARNINGS must be 0 or 1 (got '${DUCKHTS_STRICT_WARNINGS}')"
+    exit 1
+    ;;
+esac
+EXT_WARNING_FLAGS="-Wall -Wextra -Wpedantic -Wformat=2 -Wstrict-prototypes"
+# Emscripten has its own diagnostics and CMake intentionally does not make
+# them fatal. Keep the package path aligned, using the real target detection
+# above rather than host-platform assumptions.
+if [ "${DUCKHTS_STRICT_WARNINGS}" = "1" ] && [ "${WASM_BUILD}" != "yes" ]; then
+  EXT_WARNING_FLAGS="${EXT_WARNING_FLAGS} -Werror"
+fi
+EXT_CFLAGS="${CFLAGS} ${EXT_WARNING_FLAGS} -DNOCURL=1"
+# These are imported upstream implementation files. Keep their diagnostics
+# separate from the DuckHTS gate; cgranges and htslib/bcftools are maintained
+# through pinned sources and explicit patches rather than local warning churn.
+UPSTREAM_CFLAGS="${CFLAGS} -w -DNOCURL=1"
 
 add_prefix_if_header() {
   header=$1
@@ -436,7 +467,11 @@ OBJECT_FILES=""
 for src_file in $C_SOURCES; do
     obj_file="${src_file%.c}.o"
     echo "  Compiling $src_file -> $obj_file"
-  ${CC} ${EXT_CFLAGS} ${CPPFLAGS} ${INCLUDES} -c "$src_file" -o "$obj_file"
+  src_cflags="${EXT_CFLAGS}"
+  case "$src_file" in
+    cgranges.c|bcftools_filter.c) src_cflags="${UPSTREAM_CFLAGS}" ;;
+  esac
+  ${CC} ${src_cflags} ${CPPFLAGS} ${INCLUDES} -c "$src_file" -o "$obj_file"
     if [ $? -ne 0 ]; then
         echo "ERROR: Failed to compile $src_file"
         exit 1

--- a/r/Rduckhts/configure.win
+++ b/r/Rduckhts/configure.win
@@ -26,28 +26,56 @@ fi
 
 # Get R's compiler settings for Windows
 MAKE=`"${R_HOME}/bin/R" CMD config MAKE`
-CC=`"${R_HOME}/bin/R" CMD config CC`
+R_CONFIG_CC=`"${R_HOME}/bin/R" CMD config CC`
+# The Fedora-Clang CRAN-like job selects Clang without changing R's Makeconf.
+# Ordinary builds retain the compiler configured for R.
+CC="${DUCKHTS_CC:-${R_CONFIG_CC}}"
 AR=`"${R_HOME}/bin/R" CMD config AR`
 RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB`
 R_CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 R_CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 R_CPICFLAGS=`"${R_HOME}/bin/R" CMD config CPICFLAGS`
 R_LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
+if [ "${DUCKHTS_LDFLAGS+x}" = x ]; then
+    BASE_LDFLAGS="${DUCKHTS_LDFLAGS}"
+else
+    BASE_LDFLAGS="${R_LDFLAGS}"
+fi
 if [ -z "${RANLIB}" ]; then
     RANLIB=ranlib
 fi
 
 HTSLIB_DIR="${EXT_DIR}/htslib"
 DUCKDB_CAPI_HEADER="${EXT_DIR}/duckdb_capi/duckdb_extension.h"
-CFLAGS="${R_CFLAGS} ${R_CPICFLAGS} -O2 -fPIC -D_FILE_OFFSET_BITS=64"
+# A profile that intentionally selects another compiler can supply that
+# compiler's base flags without inheriting incompatible R Makeconf flags.
+BASE_CFLAGS="${DUCKHTS_CFLAGS:-${R_CFLAGS}}"
+CFLAGS="${BASE_CFLAGS} ${R_CPICFLAGS} -O2 -fPIC -D_FILE_OFFSET_BITS=64"
 # Keep htslib in a pre-C23 compiler mode.  GCC 16 defaults to GNU C23, whose
 # const-preserving string functions expose warnings in htslib 1.24.
 HTSLIB_CFLAGS="${CFLAGS} -std=gnu17"
-# Keep stricter diagnostics on DuckHTS extension sources without applying them
-# to the vendored htslib build.
-EXT_CFLAGS="${CFLAGS} -Wpedantic -DNOCURL=1"
+# Apply one warning-as-error policy to DuckHTS and bundled libBigWig sources.
+# htslib retains its upstream warning policy and GNU17 override above: it is a
+# separately built dependency, not a reason to weaken this package gate.
+DUCKHTS_STRICT_WARNINGS="${DUCKHTS_STRICT_WARNINGS:-1}"
+case "${DUCKHTS_STRICT_WARNINGS}" in
+    0|1) ;;
+    *)
+        echo "ERROR: DUCKHTS_STRICT_WARNINGS must be 0 or 1 (got '${DUCKHTS_STRICT_WARNINGS}')"
+        exit 1
+        ;;
+esac
+EXT_WARNING_FLAGS="-Wall -Wextra -Wpedantic -Wformat=2 -Wstrict-prototypes"
+if [ "${DUCKHTS_STRICT_WARNINGS}" = "1" ]; then
+    EXT_WARNING_FLAGS="${EXT_WARNING_FLAGS} -Werror"
+fi
+EXT_CFLAGS="${CFLAGS} ${EXT_WARNING_FLAGS} -DNOCURL=1"
+# These are imported upstream implementation files. Keep their diagnostics
+# separate from the DuckHTS gate; cgranges and htslib/bcftools are maintained
+# through pinned sources and explicit patches rather than local warning churn.
+UPSTREAM_CFLAGS="${CFLAGS} -w -DNOCURL=1"
 CPPFLAGS="${R_CPPFLAGS} -DNDEBUG"
-LDFLAGS="${R_LDFLAGS}"
+LDFLAGS="${BASE_LDFLAGS}"
 
 HTSLIB_VERSION_STR=`tr -d '\r\n' < "${HTSLIB_DIR}/VERSION" 2>/dev/null || true`
 HTSLIB_VERSION_NUMBER=`awk '/^#define[[:space:]]+HTS_VERSION[[:space:]]+[0-9]+/ {print $3; exit}' "${HTSLIB_DIR}/htslib/hts.h" 2>/dev/null || true`
@@ -376,7 +404,11 @@ OBJECT_FILES=""
 for src_file in $C_SOURCES; do
     obj_file="${src_file%.c}.o"
     echo "  Compiling $src_file -> $obj_file"
-    ${CC} ${EXT_CFLAGS} ${CPPFLAGS} ${INCLUDES} -c "$src_file" -o "$obj_file"
+    src_cflags="${EXT_CFLAGS}"
+    case "$src_file" in
+        cgranges.c|bcftools_filter.c) src_cflags="${UPSTREAM_CFLAGS}" ;;
+    esac
+    ${CC} ${src_cflags} ${CPPFLAGS} ${INCLUDES} -c "$src_file" -o "$obj_file"
     if [ $? -ne 0 ]; then
         echo "ERROR: Failed to compile $src_file"
         exit 1

--- a/r/Rduckhts/inst/duckhts_extension/bcftools_norm_udf.c
+++ b/r/Rduckhts/inst/duckhts_extension/bcftools_norm_udf.c
@@ -706,7 +706,8 @@ static int normalize_variant_row(norm_cache_entry_t *cache,
     char *ref_fetch = NULL;
     kstring_t *als = NULL;
     kstring_t *sym = NULL;
-    int n_allele;
+    /* The shared oom label may be reached before allele buffers exist. */
+    int n_allele = 0;
     int symbolic_alts = 1;
     int any_breakend = 0;
     int any_spanning = 0;

--- a/r/Rduckhts/inst/duckhts_extension/cgranges.c
+++ b/r/Rduckhts/inst/duckhts_extension/cgranges.c
@@ -162,7 +162,7 @@ void cr_sort(cgranges_t *cr)
 
 int32_t cr_is_sorted(const cgranges_t *cr)
 {
-	uint64_t i;
+	int64_t i;
 	for (i = 1; i < cr->n_r; ++i)
 		if (cr->r[i-1].x > cr->r[i].x)
 			break;

--- a/r/Rduckhts/inst/duckhts_extension/duckvep/duckvep_model.c
+++ b/r/Rduckhts/inst/duckhts_extension/duckvep/duckvep_model.c
@@ -808,7 +808,8 @@ duckvep_reference_descriptor_path(int descriptor, const char *source_path)
 		return NULL;
 	needed = GetFinalPathNameByHandleA(handle, NULL, 0,
 	    FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
-	if (needed == 0 || needed > SIZE_MAX - 1u)
+	/* `needed + 1` is passed back to a DWORD-sized Win32 API. */
+	if (needed == 0 || needed == (DWORD)-1)
 		return NULL;
 	path = malloc((size_t)needed + 1u);
 	if (path == NULL)

--- a/r/Rduckhts/inst/duckhts_extension/liftover_udf.c
+++ b/r/Rduckhts/inst/duckhts_extension/liftover_udf.c
@@ -630,7 +630,7 @@ static char *resolve_fasta_contig_name(faidx_t *fai, const char *chrom) {
     char with_chr[512];
     char canonical[512];
     char canonical_with_chr[512];
-    const char *aliases[12];
+    const char *aliases[12] = {NULL};
 
     if (!fai || !chrom || !*chrom) return NULL;
 

--- a/scripts/check_cran_fedora.sh
+++ b/scripts/check_cran_fedora.sh
@@ -1,39 +1,143 @@
 #!/usr/bin/env bash
-# Reproduce CRAN's r-devel-linux-x86_64-fedora-gcc package check.
+# Reproduce CRAN-like R package checks on Fedora.
 #
-# Local use launches the same R-hub Fedora/GCC container used by CI:
-#   scripts/check_cran_fedora.sh
+# Local use launches the same container/profile that GitHub Actions uses:
+#   scripts/check_cran_fedora.sh          # R-hub Fedora/GCC 16
+#   scripts/check_cran_fedora_clang.sh    # Fedora 44 / Clang 22 CRAN-like
 #
-# The container path is also the implementation called by GitHub Actions;
-# keeping both entry points here prevents the local and CI recipes drifting.
+# The Clang profile tracks the relevant public CRAN compiler configuration at
+# https://www.stats.ox.ac.uk/pub/bdr/Rconfig/r-devel-linux-x86_64-fedora-clang.
+# It deliberately uses Fedora's packaged R, not CRAN's upstream R-devel
+# runtime. The job is therefore CRAN-like rather than an exact CRAN clone.
 set -euo pipefail
 
-IMAGE="${DUCKHTS_FEDORA_IMAGE:-ghcr.io/r-hub/containers/gcc16:latest}"
+PROFILE="${DUCKHTS_FEDORA_PROFILE:-gcc}"
+case "$PROFILE" in
+    gcc)
+        DEFAULT_IMAGE="ghcr.io/r-hub/containers/gcc16:latest"
+        ;;
+    clang)
+        # Fedora 44 image pinned on 2026-07-25. The exact Fedora R and Clang
+        # packages used below are pinned and verified after installation.
+        DEFAULT_IMAGE="fedora@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898"
+        ;;
+    *)
+        echo "ERROR: DUCKHTS_FEDORA_PROFILE must be gcc or clang (got '$PROFILE')" >&2
+        exit 1
+        ;;
+esac
+IMAGE="${DUCKHTS_FEDORA_IMAGE:-$DEFAULT_IMAGE}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 if [[ "${DUCKHTS_FEDORA_CONTAINER:-0}" != "1" ]]; then
-    RLIBS_CACHE="${DUCKHTS_FEDORA_RLIBS:-${HOME}/.cache/duckhts-fedora-r-libs}"
+    RLIBS_CACHE="${DUCKHTS_FEDORA_RLIBS:-${HOME}/.cache/duckhts-fedora-${PROFILE}-r-libs}"
     mkdir -p "$RLIBS_CACHE"
     exec docker run --rm \
         -v "$REPO_ROOT:/repo" \
         -v "$RLIBS_CACHE:/root/R-libs" \
         -w /repo \
         -e DUCKHTS_FEDORA_CONTAINER=1 \
+        -e DUCKHTS_FEDORA_PROFILE="$PROFILE" \
         "$IMAGE" \
         bash scripts/check_cran_fedora.sh
 fi
 
-dnf install -y --setopt=install_weak_deps=False \
-    bzip2-devel \
-    cmake \
-    libcurl-devel \
-    libdeflate-devel \
-    openssl-devel \
-    pandoc \
-    patch \
-    pkgconf-pkg-config \
-    xz-devel \
+DNF_PACKAGES=(
+    bzip2-devel
+    cmake
+    curl
+    libcurl-devel
+    libdeflate-devel
+    openssl-devel
+    pandoc
+    patch
+    pkgconf-pkg-config
+    xz-devel
     zlib-devel
+)
+dnf install -y --setopt=install_weak_deps=False "${DNF_PACKAGES[@]}"
+
+stage_pinned_rpm() {
+    local url="$1"
+    local sha256="$2"
+    local destination="$3/$(basename "$url")"
+
+    curl --fail --location --retry 3 --connect-timeout 15 --silent --show-error \
+        --output "$destination" "$url"
+    echo "${sha256}  ${destination}" | sha256sum -c -
+}
+
+if [[ "$PROFILE" = "clang" ]]; then
+    # Pin the complete R/Clang package closure to immutable Koji artifacts.
+    # The Fedora image fixes the starting filesystem; the SHA-256 checks below
+    # prevent live Fedora repository metadata from changing the R runtime or
+    # compiler selected by this CRAN-like profile.
+    FEDORA_R_DEVEL_NEVRA="R-devel-4.6.1-1.fc44"
+    FEDORA_CLANG_NEVRA="clang-22.1.8-4.fc44"
+    FEDORA_R_KOJI_BASE="https://kojipkgs.fedoraproject.org/packages/R/4.6.1/1.fc44/x86_64"
+    # Fedora builds Clang 22.1.8 as part of the LLVM source package; its
+    # immutable RPMs are therefore under /packages/llvm/, not /packages/clang/.
+    FEDORA_LLVM_KOJI_BASE="https://kojipkgs.fedoraproject.org/packages/llvm/22.1.8/4.fc44/x86_64"
+    PINNED_RPM_DIR="$(mktemp -d /tmp/duckhts-fedora-rpms.XXXXXX)"
+
+    stage_pinned_rpm "$FEDORA_R_KOJI_BASE/R-4.6.1-1.fc44.x86_64.rpm" \
+        "51dd70927b3dc40f71e02da165ff38e65ab7e465c80e5b753de624c14466dc32" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_R_KOJI_BASE/R-core-4.6.1-1.fc44.x86_64.rpm" \
+        "ef5274cb6dbcc0cb9e3f8c275243403363c93e2ff1efeaa9bbb0c5887a208908" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_R_KOJI_BASE/R-core-devel-4.6.1-1.fc44.x86_64.rpm" \
+        "6f27f80d97a3f3fb5ee018dc98cbfdec7cdbf5e67a17d30f7df1ce3d8c1eeacd" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_R_KOJI_BASE/R-devel-4.6.1-1.fc44.x86_64.rpm" \
+        "b635fd75d7f051a702bda2d96e89d9a5e1767ef5eb5eaa891f5dccbf7196fe2f" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_R_KOJI_BASE/R-java-4.6.1-1.fc44.x86_64.rpm" \
+        "0a4ba1745ce6a1f6ac663ad1ba776e07e690b17fe96ba5fc7171abce279e3fd7" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_R_KOJI_BASE/R-java-devel-4.6.1-1.fc44.x86_64.rpm" \
+        "ad5a20e060a80f6aeff9934f815c02ed3886b28c8ffb366df1cd9faf213ef9d0" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_R_KOJI_BASE/libRmath-4.6.1-1.fc44.x86_64.rpm" \
+        "07e7e105afe258065f7b3ee9b502d1f71bc92c381856b9f69a96e2db0c40c2f9" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_R_KOJI_BASE/libRmath-devel-4.6.1-1.fc44.x86_64.rpm" \
+        "7c8d08b156604f2e0bf1317988846b4f44663aa5a724e7ca78806018c643f227" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_LLVM_KOJI_BASE/clang-22.1.8-4.fc44.x86_64.rpm" \
+        "02e9a1f927a3b3e363035ae91978deda302fb81bc81da4e5113eca4ce60b07fa" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_LLVM_KOJI_BASE/clang-libs-22.1.8-4.fc44.x86_64.rpm" \
+        "cb61748b1a32d23b7f770c36b1301d89da775105712b9f05d12b16fd526e9da4" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_LLVM_KOJI_BASE/clang-resource-filesystem-22.1.8-4.fc44.x86_64.rpm" \
+        "22edf155d2ff9c4d24177a8c99e7066d12da6368e793d0f8bc075c6b10bf2b72" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_LLVM_KOJI_BASE/llvm-filesystem-22.1.8-4.fc44.x86_64.rpm" \
+        "a427bb7d241f20dbd1cc759c63786107f7ba308425d91971811a4d2474453f6d" "$PINNED_RPM_DIR"
+    stage_pinned_rpm "$FEDORA_LLVM_KOJI_BASE/llvm-libs-22.1.8-4.fc44.x86_64.rpm" \
+        "094f63a7991a92d9ccaeb3984e8609986277dc43e12a613c01f8c69dbb10ece5" "$PINNED_RPM_DIR"
+
+    dnf install -y --setopt=install_weak_deps=False \
+        "$PINNED_RPM_DIR"/*.rpm \
+        devscripts-checkbashisms \
+        glibc-langpack-en \
+        make
+    rm -rf "$PINNED_RPM_DIR"
+    test "$(rpm -q --qf '%{NAME}-%{VERSION}-%{RELEASE}' R-devel)" = "$FEDORA_R_DEVEL_NEVRA"
+    test "$(rpm -q --qf '%{NAME}-%{VERSION}-%{RELEASE}' clang)" = "$FEDORA_CLANG_NEVRA"
+    export DUCKHTS_CC="${DUCKHTS_CC:-clang}"
+    # Fedora's packaged R was built with GCC and supplies GCC-only -specs
+    # options in R CMD config CFLAGS. Use the public CRAN Clang C flags when
+    # compiling DuckHTS itself rather than treating those foreign options as a
+    # project warning.
+    export DUCKHTS_CFLAGS="${DUCKHTS_CFLAGS:--O3 -Wall -pedantic -Wp,-D_FORTIFY_SOURCE=3}"
+    export DUCKHTS_LDFLAGS="${DUCKHTS_LDFLAGS-}"
+    export DUCKHTS_STRICT_WARNINGS=1
+    export LANG=en_US.UTF-8
+    export LC_ALL=en_US.UTF-8
+    # These are the CRAN Fedora-Clang compilation/check controls relevant to
+    # an extension package.  --as-cran supplies the standard CRAN checks.
+    export _R_CHECK_COMPILATION_FLAGS_=true
+    export _R_CHECK_INSTALL_DEPENDS_=true
+    export _R_CHECK_SUGGESTS_ONLY_=true
+    export _R_CHECK_NO_RECOMMENDED_=true
+    export _R_CHECK_DEPRECATED_DEFUNCT_=true
+    export _R_CHECK_FF_CALLS_=registration
+    export _R_CHECK_PRAGMAS_=true
+    "${DUCKHTS_CC}" --version
+fi
+R --version | head -n 1
+R CMD config CC
 
 mkdir -p /root/R-libs
 export R_LIBS_USER=/root/R-libs
@@ -68,8 +172,15 @@ set -e
 
 CHECK_LOG="$CHECK_ROOT/Rduckhts.Rcheck/00check.log"
 test -f "$CHECK_LOG"
+if [ "$check_status" -ne 0 ]; then
+    INSTALL_LOG="$CHECK_ROOT/Rduckhts.Rcheck/00install.out"
+    if [ -f "$INSTALL_LOG" ]; then
+        echo "--- $INSTALL_LOG (last 240 lines) ---" >&2
+        tail -n 240 "$INSTALL_LOG" >&2
+    fi
+fi
 if grep -Eq '^Status:.*(ERROR|WARNING)' "$CHECK_LOG"; then
-    echo "Fedora GCC 16 check produced an ERROR or WARNING" >&2
+    echo "Fedora ${PROFILE} check produced an ERROR or WARNING" >&2
     exit 1
 fi
 exit "$check_status"

--- a/scripts/check_cran_fedora_clang.sh
+++ b/scripts/check_cran_fedora_clang.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Reproduce the CRAN-like Fedora 44 / Clang 22 package check.
+# See scripts/check_cran_fedora.sh for the pinned image and scope.
+set -euo pipefail
+
+export DUCKHTS_FEDORA_PROFILE=clang
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check_cran_fedora.sh"

--- a/scripts/vendor_cgranges.sh
+++ b/scripts/vendor_cgranges.sh
@@ -61,6 +61,8 @@ for f in "${FILES[@]}"; do
   cp "$CACHE_DIR/$f" "$TARGET_DIR/$f"
 done
 
+apply_patches "$TARGET_DIR" cgranges
+
 echo "$CGRANGES_COMMIT" > "$TARGET_DIR/COMMIT"
 echo "https://github.com/lh3/cgranges/tree/$CGRANGES_COMMIT" > "$TARGET_DIR/SOURCE_URL"
 

--- a/src/bcftools_norm_udf.c
+++ b/src/bcftools_norm_udf.c
@@ -706,7 +706,8 @@ static int normalize_variant_row(norm_cache_entry_t *cache,
     char *ref_fetch = NULL;
     kstring_t *als = NULL;
     kstring_t *sym = NULL;
-    int n_allele;
+    /* The shared oom label may be reached before allele buffers exist. */
+    int n_allele = 0;
     int symbolic_alts = 1;
     int any_breakend = 0;
     int any_spanning = 0;

--- a/src/duckvep/duckvep_model.c
+++ b/src/duckvep/duckvep_model.c
@@ -808,7 +808,8 @@ duckvep_reference_descriptor_path(int descriptor, const char *source_path)
 		return NULL;
 	needed = GetFinalPathNameByHandleA(handle, NULL, 0,
 	    FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
-	if (needed == 0 || needed > SIZE_MAX - 1u)
+	/* `needed + 1` is passed back to a DWORD-sized Win32 API. */
+	if (needed == 0 || needed == (DWORD)-1)
 		return NULL;
 	path = malloc((size_t)needed + 1u);
 	if (path == NULL)

--- a/src/liftover_udf.c
+++ b/src/liftover_udf.c
@@ -630,7 +630,7 @@ static char *resolve_fasta_contig_name(faidx_t *fai, const char *chrom) {
     char with_chr[512];
     char canonical[512];
     char canonical_with_chr[512];
-    const char *aliases[12];
+    const char *aliases[12] = {NULL};
 
     if (!fai || !chrom || !*chrom) return NULL;
 

--- a/third_party/cgranges/cgranges.c
+++ b/third_party/cgranges/cgranges.c
@@ -162,7 +162,7 @@ void cr_sort(cgranges_t *cr)
 
 int32_t cr_is_sorted(const cgranges_t *cr)
 {
-	uint64_t i;
+	int64_t i;
 	for (i = 1; i < cr->n_r; ++i)
 		if (cr->r[i-1].x > cr->r[i].x)
 			break;

--- a/third_party/patches/cgranges/0001-use-signed-range-index-in-sortedness-check.patch
+++ b/third_party/patches/cgranges/0001-use-signed-range-index-in-sortedness-check.patch
@@ -1,0 +1,6 @@
+diff --git a/cgranges.c b/cgranges.c
+--- a/cgranges.c
++++ b/cgranges.c
+@@ -165 +165 @@
+-	uint64_t i;
++	int64_t i;


### PR DESCRIPTION
## Summary

- make DuckHTS-owned native package compilation warning-fatal by default, while retaining explicit upstream-source boundaries
- add a pinned Fedora 44 / Fedora-packaged R 4.6.1 / Clang 22.1.8 local and GitHub CRAN-like check, based on the public [CRAN Fedora-Clang configuration](https://www.stats.ox.ac.uk/pub/bdr/Rconfig/r-devel-linux-x86_64-fedora-clang)
- make `r-lib/actions/check-r-package` fail on warnings, fix the diagnostics exposed by the new gate, and keep `Rduckhts` package cleanup from mutating bundled htslib source fixtures

## Validation

- `scripts/check_cran_fedora_clang.sh` against the exact PR archive: Fedora 44, Fedora-packaged R 4.6.1, Clang 22.1.8; `R CMD check --as-cran` completed with only the standard CRAN incoming NOTE, and tinytests passed
- `CC=clang make release -j2` completed under Clang 18.1.3 with the native CMake warning gate enabled
- `scripts/vendor_cgranges.sh`
- `git diff --check origin/main..fix/cran-strict-clang-ci`

## Performance

This change affects compilation policy, CI, cleanup safety, and warning-clean source maintenance; it does not alter a measured hot path. No same-revision throughput benchmark was run and no no-regression claim is made.

Nearest checked-in rendered baseline: `benchmarks/benchmark_gffbase_conformance.md`, source revision `a490a1945d9e+dirty`. Its `read_gff COUNT(*)` GENCODE v49 workload scanned 5,866,158 input records and returned one count over three timed passes with four DuckDB threads; median was 1.9906 s (2,946,870.9 rows/s). This is not comparable to the present CI/compiler work. The missing measurement is a same-revision workload only if a future compiler-policy change is shown to affect generated code or runtime behavior.
