### PR TITLE
Fix M1Mac package compiler-warning policy

### DIFF
--- a/.github/workflows/cran-check.yml
+++ b/.github/workflows/cran-check.yml
@@ -86,6 +86,17 @@ jobs:
       #  run: |
       #    brew install pkg-config curl gsl libdeflate bzip2 xz openssl
 
+      - name: Reproduce CRAN M1Mac conversion diagnostics
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "DUCKHTS_CFLAGS=$(R CMD config CFLAGS) -Wconversion -Wno-sign-conversion" >> "$GITHUB_ENV"
+
+      - name: Enable strict Windows native diagnostics
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "DUCKHTS_STRICT_WARNINGS=1" >> "$GITHUB_ENV"
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
@@ -98,3 +109,17 @@ jobs:
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
           error-on: '"warning"'
           working-directory: r/Rduckhts
+
+      - name: Verify htslib header diagnostics stay outside DuckHTS compilation
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          install_log=$(find r/Rduckhts -type f -path '*/Rduckhts.Rcheck/00install.out' -print -quit)
+          test -n "$install_log"
+          extension_log=$(mktemp)
+          awk '/Building DuckHTS extension/ { extension = 1 } extension { print }' "$install_log" > "$extension_log"
+          test -s "$extension_log"
+          if grep -E 'htslib/htslib/[^:]+:[0-9]+:[0-9]+: (warning|error):' "$extension_log"; then
+            echo "vendored htslib header diagnostics leaked into DuckHTS compilation" >&2
+            exit 1
+          fi

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,11 @@
   Linux libc++ toolchains. File-backed connections reject a reused DuckDB
   driver whose creation policy cannot be changed, and failed new connections
   release their driver
-- make native DuckHTS builds promote their compiler diagnostics to errors by
-  default, while keeping pinned upstream implementation diagnostics isolated
+- make native DuckHTS CMake builds and explicit CI profiles promote package-owned
+  compiler diagnostics to errors while released R package builds preserve the
+  warning policy supplied by R and the installation environment. Vendored htslib
+  headers are system includes in Unix-like package builds, and the macOS package
+  check now reproduces CRAN M1Mac's conversion-warning flags
 - initialize the `bcftools_norm_row` shared out-of-memory cleanup count before
   any allocation can fail, avoiding an indeterminate cleanup-loop bound
 - patch pinned libBigWig's `bwCleanup` definition to match its public

--- a/r/Rduckhts/DESCRIPTION
+++ b/r/Rduckhts/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rduckhts
 Title: 'DuckDB' High Throughput Sequencing File Formats Reader Extension
-Version: 1.5.1-0.1.1
+Version: 1.5.1-0.1.2
 Authors@R: c(
     person(given = "Sounkou Mahamane", family = "Toure",
     email = "sounkoutoure@gmail.com",

--- a/r/Rduckhts/NEWS.md
+++ b/r/Rduckhts/NEWS.md
@@ -1,5 +1,10 @@
 
 # Rduckhts 1.5.1-0.1.1
+- preserve R and site compiler-warning policy during released package installs
+  instead of promoting every externally enabled warning to an error. Strict
+  package-owned diagnostics remain an explicit CI gate, vendored htslib headers
+  are system includes in Unix-like package builds, and the macOS package check
+  reproduces CRAN M1Mac's conversion-warning flags
 - add `rduckhts_connect()` as the single package-owned connection path. It
   explicitly permits the locally compiled bundled extension, uses temporary
   DuckDB extension/secret storage when supported, and disables implicit known-

--- a/r/Rduckhts/NEWS.md
+++ b/r/Rduckhts/NEWS.md
@@ -1,5 +1,5 @@
 
-# Rduckhts 1.5.1-0.1.1
+# Rduckhts 1.5.1-0.1.2
 - preserve R and site compiler-warning policy during released package installs
   instead of promoting every externally enabled warning to an error. Strict
   package-owned diagnostics remain an explicit CI gate, vendored htslib headers

--- a/r/Rduckhts/configure
+++ b/r/Rduckhts/configure
@@ -97,10 +97,10 @@ fi
 # vendored dependency; DuckHTS sources continue to use R's compiler mode.
 HTSLIB_CFLAGS="${CFLAGS} -std=gnu17"
 
-# Apply one warning-as-error policy to DuckHTS and bundled libBigWig sources.
-# htslib retains its upstream warning policy and GNU17 override above: it is a
-# separately built dependency, not a reason to weaken this package gate.
-DUCKHTS_STRICT_WARNINGS="${DUCKHTS_STRICT_WARNINGS:-1}"
+# Released package builds preserve the warning policy supplied by R and the
+# installation environment. CI opts into warning-as-error checks for DuckHTS
+# and bundled libBigWig sources; htslib retains its upstream warning policy.
+DUCKHTS_STRICT_WARNINGS="${DUCKHTS_STRICT_WARNINGS:-0}"
 case "${DUCKHTS_STRICT_WARNINGS}" in
   0|1) ;;
   *)
@@ -460,7 +460,7 @@ echo "---------- Building DuckHTS extension ----------"
 cd "${EXT_DIR}"
 
 C_SOURCES="duckhts.c simd/duckhts_simd_dispatch.c simd/duckhts_simd_scalar.c simd/duckhts_simd_avx2.c simd/duckhts_simd_avx512.c simd/duckhts_simd_neon.c simd/duckhts_simd_wasm_simd128.c bcf_reader.c bam_reader.c bam_pileup.c bgzip.c hts_index_builder.c liftover_udf.c bcftools_norm_udf.c munge_udf.c seq_reader.c fastq_qc.c interval_udf.c tabix_reader.c bigwig_reader.c libbigwig_hfile_io.c hts_meta_reader.c quality_encoding.c quality_encoding_reader.c mosdepth_table.c bam_bin_counts.c samtools_idxstats_table.c bam_bed_coverage.c cgranges_api.c variantkey_udf.c cgranges.c libBigWig/bwRead.c libBigWig/bwValues.c bcftools_filter.c bcftools_shim.c score_udf.c vep_parser.c duckvep/kernel/src/duckvep_kernel.c duckvep/kernel/src/duckvep_so.c duckvep/kernel/src/duckvep_sweep.c duckvep/kernel/src/duckvep_classify.c duckvep/kernel/src/duckvep_effect.c duckvep/kernel/src/duckvep_sv.c duckvep/kernel/src/duckvep_delta.c duckvep/kernel/src/duckvep_projection.c duckvep/kernel/src/duckvep_transcript_edit.c duckvep/kernel/src/duckvep_hgvs.c duckvep/kernel/src/duckvep_codon.c duckvep/kernel/src/duckvep_coding.c duckvep/kernel/src/duckvep_haplotype.c duckvep/duckvep_variant_tile.c duckvep/duckvep_model.c duckvep/duckvep_annotate.c duckvep/duckvep_ensembl.c duckvep/duckvep_sql.c kmer_udf.c wasm_http_hfile.c"
-INCLUDES="-I./include -I./duckdb_capi -I./htslib -I./libBigWig -I./duckvep/kernel/include -I./duckvep/kernel/src"
+INCLUDES="-I./include -I./duckdb_capi -isystem ./htslib -I./libBigWig -I./duckvep/kernel/include -I./duckvep/kernel/src"
 
 echo "Compiling extension sources..."
 OBJECT_FILES=""

--- a/r/Rduckhts/configure.win
+++ b/r/Rduckhts/configure.win
@@ -54,10 +54,10 @@ CFLAGS="${BASE_CFLAGS} ${R_CPICFLAGS} -O2 -fPIC -D_FILE_OFFSET_BITS=64"
 # Keep htslib in a pre-C23 compiler mode.  GCC 16 defaults to GNU C23, whose
 # const-preserving string functions expose warnings in htslib 1.24.
 HTSLIB_CFLAGS="${CFLAGS} -std=gnu17"
-# Apply one warning-as-error policy to DuckHTS and bundled libBigWig sources.
-# htslib retains its upstream warning policy and GNU17 override above: it is a
-# separately built dependency, not a reason to weaken this package gate.
-DUCKHTS_STRICT_WARNINGS="${DUCKHTS_STRICT_WARNINGS:-1}"
+# Released package builds preserve the warning policy supplied by R and the
+# installation environment. CI opts into warning-as-error checks for DuckHTS
+# and bundled libBigWig sources; htslib retains its upstream warning policy.
+DUCKHTS_STRICT_WARNINGS="${DUCKHTS_STRICT_WARNINGS:-0}"
 case "${DUCKHTS_STRICT_WARNINGS}" in
     0|1) ;;
     *)

--- a/r/Rduckhts/cran-comments.md
+++ b/r/Rduckhts/cran-comments.md
@@ -7,8 +7,12 @@ issues.
 It fixes the reported native diagnostics, including uninitialized normalization
 cleanup state and liftover alias pointers, unused coverage, interval, and VEP
 code, the libBigWig `bwCleanup` prototype, and MinGW visibility and
-allocation-size checks. Package-owned compiler warnings are now treated as
-errors.
+allocation-size checks.
+
+This resubmission no longer promotes compiler warnings supplied by R or the
+installation environment to errors. Strict package-owned diagnostics remain an
+explicit CI check, and vendored htslib headers are treated as system headers in
+Unix-like package builds. This fixes the reported M1Mac installation failure.
 
 It also adds `rduckhts_connect()` to permit loading the bundled extension with
 `duckdb` 1.5.5, fixing the Fedora-Clang example and tinytest errors. There is no


### PR DESCRIPTION
## Summary

This resubmission fix stops released R package builds from promoting compiler warnings supplied by R or the installation environment to errors. Strict DuckHTS-owned diagnostics remain explicit CI policy. Unix-like package builds classify vendored htslib headers as system headers, the macOS job reproduces CRAN M1Mac's `-Wconversion -Wno-sign-conversion` profile, and Windows retains an explicit strict native-diagnostics gate. The corrected R package artifact is version `1.5.1-0.1.2`; the bundled extension remains `1.5.1`.

## Validation

`Rduckhts_1.5.1-0.1.2.tar.gz` was built and checked locally with Clang and the M1Mac conversion flags. It completed with 0 errors, 0 warnings, and the expected CRAN incoming NOTE. No htslib header diagnostic leaked into the DuckHTS extension-compilation phase. PR checks exercise the macOS conversion profile, strict Windows and Fedora-Clang profiles, Fedora GCC 16, Ubuntu release/devel, ARM64, extension distribution builds, and wasm.

## Performance

No checked-in benchmark exercises compiler-warning policy, and this change does not modify a measured runtime path. The nearest rendered baseline is `benchmarks/benchmark_gffbase_conformance.md`, source revision `a490a1945d9e+dirty`, using 4 DuckDB threads, three timed passes, and 200,000-row synthetic plus 5,866,158-row GENCODE GFF3 inputs; output denominators are parsed/scanned rows. It records 18,297,703.7 rows/s for synthetic `read_gff COUNT(*)` and 2,946,870.9 rows/s for GENCODE `read_gff COUNT(*)`. No runtime measurement is applicable to this build-policy correction.
