### PR TITLE
fix: validate R-universe architecture receipts

### DIFF
--- a/.github/workflows/r-universe-sync.yaml
+++ b/.github/workflows/r-universe-sync.yaml
@@ -30,6 +30,8 @@ jobs:
         env:
           API_URL: https://rgenomicsetl.r-universe.dev/api/packages/Rduckhts
           CDN_URL: https://cdn.r-universe.dev
+          GH_API: https://api.github.com
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           json=$(curl -fsSL "$API_URL")
@@ -42,7 +44,7 @@ jobs:
 
           while IFS= read -r row; do
             index=$((index + 1))
-            _jq() { echo "$row" | base64 -d | jq -r "$1"; }
+            _jq() { printf '%s' "$row" | base64 -d | jq -r "$1"; }
             os=$(_jq '.os // empty')
             rver=$(_jq '.r // empty')
             distro=$(_jq '.distro // empty')
@@ -102,6 +104,40 @@ jobs:
           fi
 
           echo "$version" > dist/latest-version.txt
+
+          # Remove every prior asset for this package version.  This is
+          # necessary because the old synchronizer could leave an amd64 or
+          # arm64 asset under the other platform's name; uploading corrected
+          # names alone would leave those unsafe assets servable.
+          release_url="$GH_API/repos/$GITHUB_REPOSITORY/releases/tags/r-universe-binaries"
+          release_json_file="dist/release.json"
+          release_status=$(curl -sS -o "$release_json_file" -w "%{http_code}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "$release_url" || true)
+          case "$release_status" in
+            200)
+              while IFS= read -r asset_id; do
+                [ -n "$asset_id" ] || continue
+                curl -fsSL -X DELETE \
+                  -H "Authorization: Bearer $GH_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "$GH_API/repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"
+              done < <(
+                jq -r --arg prefix "Rduckhts_${version}_" \
+                  '.assets[]? | select(.name | startswith($prefix)) | .id' \
+                  "$release_json_file"
+              )
+              ;;
+            404)
+              ;;
+            *)
+              cat "$release_json_file" >&2
+              echo "Could not inspect the r-universe-binaries release (HTTP $release_status)" >&2
+              exit 1
+              ;;
+          esac
+
           echo "publish=yes" >> "$GITHUB_OUTPUT"
 
       - name: Upload workflow artifacts

--- a/.github/workflows/r-universe-sync.yaml
+++ b/.github/workflows/r-universe-sync.yaml
@@ -22,61 +22,80 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq zip
 
+      - name: Test artifact receipt validator
+        run: python3 test/scripts/test_r_universe_artifact.py
+
       - name: Download R-universe artifacts
         id: sync
         env:
           API_URL: https://rgenomicsetl.r-universe.dev/api/packages/Rduckhts
           CDN_URL: https://cdn.r-universe.dev
-          GH_API: https://api.github.com
         run: |
           set -euo pipefail
-          json=$(curl -s "$API_URL")
-          version=$(echo "$json" | jq -r '.Version')
+          json=$(curl -fsSL "$API_URL")
+          version=$(jq -er '.Version // empty' <<<"$json")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-          release_url="$GH_API/repos/$GITHUB_REPOSITORY/releases/tags/r-universe-binaries"
-          if [ -n "${GITHUB_TOKEN:-}" ]; then
-            release_json=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "$release_url" || true)
-          else
-            release_json=$(curl -s -H "Accept: application/vnd.github+json" "$release_url" || true)
-          fi
+          mkdir -p dist/binaries dist/downloads dist/zips
+          declare -A seen_suffixes=()
+          index=0
 
-          mkdir -p dist/binaries dist/zips
-
-          echo "$json" | jq -r '._binaries[] | @base64' | while read -r row; do
+          while IFS= read -r row; do
+            index=$((index + 1))
             _jq() { echo "$row" | base64 -d | jq -r "$1"; }
-            os=$(_jq '.os')
-            rver=$(_jq '.r')
-            distro=$(_jq '.distro')
-            fileid=$(_jq '.fileid')
+            os=$(_jq '.os // empty')
+            rver=$(_jq '.r // empty')
+            distro=$(_jq '.distro // empty')
+            fileid=$(_jq '.fileid // empty')
 
-            if [ -z "$fileid" ] || [ "$fileid" = "null" ]; then
+            # R-universe lists unavailable builds without a fileid.  There is
+            # no package receipt to validate or publish in that case.
+            if [ -z "$fileid" ]; then
               continue
             fi
+            if [[ ! "$rver" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
+              echo "Invalid R version in R-universe API: $rver" >&2
+              exit 1
+            fi
 
-            case "$os" in
-              win) triplet="windows_amd64_mingw";;
-              mac) triplet="osx_arm64";;
-              linux) triplet="linux_amd64";;
-              *) triplet="$os";;
+            case "$fileid" in
+              http://*|https://*) download_url="$fileid";;
+              *) download_url="${CDN_URL%/}/${fileid#/}";;
             esac
 
-            suffix="${triplet}_r${rver}"
-            if [ -n "$distro" ] && [ "$distro" != "null" ] && [ "$os" = "linux" ]; then
+            download_dir="dist/downloads/$index"
+            mkdir -p "$download_dir"
+            (cd "$download_dir" && curl -fsSL -L -J -O "$download_url")
+            mapfile -t package_files < <(find "$download_dir" -maxdepth 1 -type f -print)
+            if [ "${#package_files[@]}" -ne 1 ]; then
+              echo "Expected one downloaded R-universe package for API row $index" >&2
+              exit 1
+            fi
+            package_file="${package_files[0]}"
+
+            platform=$(python3 scripts/validate_r_universe_artifact.py \
+              --package "$package_file" \
+              --api-os "$os" \
+              --expected-version "$version" \
+              --expected-r-version "$rver")
+            suffix="${platform}_r${rver}"
+            if [ -n "$distro" ] && [ "$os" = "linux" ]; then
               suffix="${suffix}_${distro}"
             fi
+            if [[ -n "${seen_suffixes[$suffix]+set}" ]]; then
+              echo "Duplicate receipted artifact suffix: $suffix" >&2
+              exit 1
+            fi
+            seen_suffixes["$suffix"]=1
 
             outdir="dist/binaries/${suffix}"
             mkdir -p "$outdir"
-            (cd "$outdir" && curl -L -O -J "$CDN_URL/$fileid")
+            package_name=$(basename "$package_file")
+            cp "$package_file" "$outdir/$package_name"
+            (cd "$outdir" && zip -q -r "../../zips/Rduckhts_${version}_${suffix}.zip" "$package_name")
+          done < <(jq -r '._binaries[]? | @base64' <<<"$json")
 
-            pkg_file=$(ls -t "$outdir" | head -n 1)
-            if [ -n "$pkg_file" ]; then
-              (cd "$outdir" && zip -r "../../zips/Rduckhts_${version}_${suffix}.zip" "$pkg_file")
-            fi
-          done
-
-          if ! ls dist/zips/*.zip >/dev/null 2>&1; then
+          if ! compgen -G 'dist/zips/*.zip' >/dev/null; then
             echo "No binaries found to publish"
             echo "publish=no" >> "$GITHUB_OUTPUT"
             exit 0

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
   target-specific `Built` field instead of classifying configure-built DuckHTS
   and htslib artifacts as architecture-independent
 
+- make the nightly R-universe artifact sync validate the package `Built` field
+  against the bundled DuckDB extension footer, publish only the receipted
+  platform name, and fail on missing or contradictory architecture metadata
+
 # duckhts 1.5.1
 - mark Rduckhts as requiring compilation because its configure scripts build
   target-specific DuckHTS and htslib artifacts outside the conventional R

--- a/r/Rduckhts/NEWS.md
+++ b/r/Rduckhts/NEWS.md
@@ -11,6 +11,10 @@
   prevents configure-built DuckHTS and htslib artifacts from being treated as
   architecture-independent and reused across Linux, macOS, or Windows targets
 
+- validate R-universe binary packages against both their `Built` field and
+  bundled DuckDB extension footer, preventing a package built for one target
+  from being published under another architecture
+
 # Rduckhts 1.5.1-0.1.4
 - declare `NeedsCompilation: yes` because package configuration compiles
   target-specific DuckHTS and htslib artifacts outside the conventional R

--- a/scripts/validate_r_universe_artifact.py
+++ b/scripts/validate_r_universe_artifact.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Validate an R-universe Rduckhts binary package receipt.
+
+The R package DESCRIPTION and the bundled DuckDB extension footer are two
+independent records of the build target.  Artifact publishing must use their
+intersection, not the coarse operating-system label returned by R-universe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+FOOTER_SIZE = 534
+FOOTER_MAGIC = b"\x00\x93\x04\x10"
+FOOTER_SIGNATURE = b"duckdb_signature"
+FOOTER_HEADER = b"\x80\x04"
+
+# These names are the DuckDB extension platform values emitted by the package
+# configure scripts.  linux_i686_musl is the existing receipt value for the
+# Emscripten/webR package path.
+SUPPORTED_PLATFORMS = frozenset(
+    {
+        "linux_amd64",
+        "linux_arm64",
+        "linux_i686_musl",
+        "osx_amd64",
+        "osx_arm64",
+        "windows_amd64_mingw",
+        "windows_arm64_mingw",
+    }
+)
+API_OS_PLATFORMS = {
+    "linux": frozenset({"linux_amd64", "linux_arm64"}),
+    "mac": frozenset({"osx_amd64", "osx_arm64"}),
+    "win": frozenset({"windows_amd64_mingw", "windows_arm64_mingw"}),
+    "wasm": frozenset({"linux_i686_musl"}),
+}
+
+DESCRIPTION_PATH = "Rduckhts/DESCRIPTION"
+EXTENSION_SUFFIX = "Rduckhts/duckhts_extension/build/duckhts.duckdb_extension"
+
+
+class ArtifactValidationError(ValueError):
+    """A package does not contain a self-consistent build receipt."""
+
+
+@dataclass(frozen=True)
+class ArtifactReceipt:
+    package_version: str
+    built_r_version: str
+    built_target: str
+    platform: str
+    duckdb_version: str
+
+
+def _find_unique_member(names: Iterable[str], expected: str) -> str:
+    matches = [name for name in names if name == expected or name.endswith("/" + expected)]
+    if len(matches) != 1:
+        if not matches:
+            raise ArtifactValidationError(f"package is missing {expected}")
+        raise ArtifactValidationError(f"package contains multiple copies of {expected}")
+    return matches[0]
+
+
+def _read_tar_member(package: Path, expected: str) -> bytes:
+    try:
+        with tarfile.open(package, mode="r:*") as archive:
+            member_name = _find_unique_member((m.name for m in archive.getmembers()), expected)
+            member = archive.getmember(member_name)
+            if not member.isfile():
+                raise ArtifactValidationError(
+                    f"package member is not a regular file: {member_name}"
+                )
+            stream = archive.extractfile(member)
+            if stream is None:
+                raise ArtifactValidationError(f"could not read package member: {member_name}")
+            return stream.read()
+    except ArtifactValidationError:
+        raise
+    except (OSError, tarfile.TarError) as exc:
+        raise ArtifactValidationError(f"not a readable tar package: {package}") from exc
+
+
+def _read_zip_member(package: Path, expected: str) -> bytes:
+    try:
+        with zipfile.ZipFile(package) as archive:
+            member_name = _find_unique_member(archive.namelist(), expected)
+            info = archive.getinfo(member_name)
+            if info.is_dir():
+                raise ArtifactValidationError(
+                    f"package member is not a regular file: {member_name}"
+                )
+            return archive.read(info)
+    except ArtifactValidationError:
+        raise
+    except (OSError, zipfile.BadZipFile, KeyError) as exc:
+        raise ArtifactValidationError(f"not a readable zip package: {package}") from exc
+
+
+def _read_member(package: Path, expected: str) -> bytes:
+    try:
+        return _read_tar_member(package, expected)
+    except ArtifactValidationError as tar_error:
+        try:
+            return _read_zip_member(package, expected)
+        except ArtifactValidationError as zip_error:
+            raise ArtifactValidationError(
+                f"could not read {expected} from {package}: {tar_error}; {zip_error}"
+            ) from zip_error
+
+
+def _dcf_fields(description: bytes) -> dict[str, str]:
+    try:
+        text = description.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ArtifactValidationError("DESCRIPTION is not UTF-8") from exc
+
+    fields: dict[str, str] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        if line[:1].isspace():
+            if current is not None:
+                fields[current] += " " + line.strip()
+            continue
+        if ":" not in line:
+            current = None
+            continue
+        name, value = line.split(":", 1)
+        current = name.strip()
+        fields[current] = value.strip()
+    return fields
+
+
+def _built_info(fields: dict[str, str]) -> tuple[str, str]:
+    built = fields.get("Built", "")
+    parts = [part.strip() for part in built.split(";")]
+    if len(parts) < 2 or not parts[0].startswith("R ") or not parts[1]:
+        raise ArtifactValidationError("DESCRIPTION has no valid Built target")
+    built_r_version = parts[0][2:].strip()
+    if not re.fullmatch(r"[0-9]+(?:\.[0-9]+)+", built_r_version):
+        raise ArtifactValidationError(
+            f"DESCRIPTION has an invalid Built R version: {built_r_version}"
+        )
+    return built_r_version, parts[1]
+
+
+def target_to_platform(target: str) -> str:
+    """Map an R Built target to the package's exact DuckDB platform value."""
+    normalized = target.strip().lower()
+    if normalized == "wasm32-unknown-emscripten":
+        return "linux_i686_musl"
+    if normalized.startswith(("aarch64-", "arm64-")) and "-linux-" in normalized:
+        return "linux_arm64"
+    if normalized.startswith("x86_64-") and "-linux-" in normalized:
+        return "linux_amd64"
+    if normalized.startswith(("aarch64-", "arm64-")) and "-apple-darwin" in normalized:
+        return "osx_arm64"
+    if normalized.startswith("x86_64-") and "-apple-darwin" in normalized:
+        return "osx_amd64"
+    if normalized.startswith(("aarch64-", "arm64-")) and normalized.endswith("-w64-mingw32"):
+        return "windows_arm64_mingw"
+    if normalized.startswith("x86_64-") and normalized.endswith("-w64-mingw32"):
+        return "windows_amd64_mingw"
+    raise ArtifactValidationError(f"unsupported R Built target: {target}")
+
+
+def _field(footer: bytes, offset: int, name: str) -> str:
+    raw = footer[offset : offset + 32]
+    if len(raw) != 32:
+        raise ArtifactValidationError(f"DuckDB footer is missing {name}")
+    value, separator, padding = raw.partition(b"\0")
+    if not separator:
+        padding = b""
+    if any(byte != 0 for byte in padding):
+        raise ArtifactValidationError(f"DuckDB footer has non-zero {name} padding")
+    try:
+        decoded = value.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ArtifactValidationError(f"DuckDB footer {name} is not ASCII") from exc
+    if not decoded:
+        raise ArtifactValidationError(f"DuckDB footer has an empty {name}")
+    return decoded
+
+
+def _footer_receipt(extension: bytes) -> tuple[str, str, str]:
+    if len(extension) < FOOTER_SIZE:
+        raise ArtifactValidationError("DuckDB extension is shorter than its metadata footer")
+    footer = extension[-FOOTER_SIZE:]
+    if footer[:4] != FOOTER_MAGIC or footer[4:20] != FOOTER_SIGNATURE:
+        raise ArtifactValidationError("DuckDB extension has no recognized metadata footer")
+    if footer[20:22] != FOOTER_HEADER:
+        raise ArtifactValidationError("DuckDB extension metadata footer has an invalid header")
+    extension_version = _field(footer, 150, "extension version")
+    duckdb_version = _field(footer, 182, "DuckDB API version")
+    platform = _field(footer, 214, "platform")
+    if platform not in SUPPORTED_PLATFORMS:
+        raise ArtifactValidationError(f"unsupported DuckDB footer platform: {platform}")
+    return extension_version, duckdb_version, platform
+
+
+def validate_artifact(
+    package: str | Path,
+    api_os: str,
+    expected_version: str,
+    expected_r_version: str | None = None,
+) -> ArtifactReceipt:
+    """Validate one R-universe package and return its exact receipt."""
+    package_path = Path(package)
+    if not package_path.is_file():
+        raise ArtifactValidationError(f"package does not exist: {package_path}")
+    if api_os not in API_OS_PLATFORMS:
+        raise ArtifactValidationError(f"unsupported R-universe operating system: {api_os}")
+    if not expected_version:
+        raise ArtifactValidationError("expected package version is empty")
+
+    fields = _dcf_fields(_read_member(package_path, DESCRIPTION_PATH))
+    package_version = fields.get("Version", "")
+    if package_version != expected_version:
+        raise ArtifactValidationError(
+            f"package Version {package_version!r} disagrees with API Version {expected_version!r}"
+        )
+    if fields.get("NeedsCompilation") != "yes":
+        raise ArtifactValidationError("binary package does not declare NeedsCompilation: yes")
+
+    built_r_version, built_target = _built_info(fields)
+    if expected_r_version is not None and built_r_version != expected_r_version:
+        raise ArtifactValidationError(
+            f"package Built R version {built_r_version!r} disagrees with API R version "
+            f"{expected_r_version!r}"
+        )
+    built_platform = target_to_platform(built_target)
+    extension_version, duckdb_version, footer_platform = _footer_receipt(
+        _read_member(package_path, EXTENSION_SUFFIX)
+    )
+    if extension_version != expected_version:
+        raise ArtifactValidationError(
+            f"DuckDB footer extension version {extension_version!r} disagrees with API Version "
+            f"{expected_version!r}"
+        )
+    if built_platform != footer_platform:
+        raise ArtifactValidationError(
+            f"DESCRIPTION Built target {built_target!r} resolves to {built_platform!r}, "
+            f"but DuckDB footer records {footer_platform!r}"
+        )
+    if footer_platform not in API_OS_PLATFORMS[api_os]:
+        raise ArtifactValidationError(
+            f"R-universe os {api_os!r} disagrees with DuckDB footer platform {footer_platform!r}"
+        )
+    return ArtifactReceipt(
+        expected_version,
+        built_r_version,
+        built_target,
+        footer_platform,
+        duckdb_version,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package", required=True, type=Path)
+    parser.add_argument("--api-os", required=True, choices=sorted(API_OS_PLATFORMS))
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--expected-r-version", required=True)
+    args = parser.parse_args(argv)
+    try:
+        receipt = validate_artifact(
+            args.package,
+            args.api_os,
+            args.expected_version,
+            args.expected_r_version,
+        )
+    except ArtifactValidationError as exc:
+        print(f"artifact receipt validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(receipt.platform)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_r_universe_artifact.py
+++ b/test/scripts/test_r_universe_artifact.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Mocked package receipt tests for the R-universe synchronizer."""
+
+from __future__ import annotations
+
+import io
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from validate_r_universe_artifact import (  # noqa: E402
+    ArtifactValidationError,
+    FOOTER_HEADER,
+    FOOTER_MAGIC,
+    FOOTER_SIGNATURE,
+    FOOTER_SIZE,
+    validate_artifact,
+)
+
+
+VERSION = "1.5.1.9000-0.1.5"
+DESCRIPTION_PATH = "Rduckhts/DESCRIPTION"
+EXTENSION_PATH = "Rduckhts/duckhts_extension/build/duckhts.duckdb_extension"
+
+
+def _field(value: str) -> bytes:
+    encoded = value.encode("ascii")
+    if len(encoded) > 32:
+        raise ValueError(value)
+    return encoded + b"\0" * (32 - len(encoded))
+
+
+def _extension(platform: str, version: str = VERSION) -> bytes:
+    footer = b"".join(
+        (
+            FOOTER_MAGIC,
+            FOOTER_SIGNATURE,
+            FOOTER_HEADER,
+            _field(""),
+            _field(""),
+            _field(""),
+            _field("C_STRUCT"),
+            _field(version),
+            _field("v1.2.0"),
+            _field(platform),
+            _field("4"),
+            b"\0" * 256,
+        )
+    )
+    if len(footer) != FOOTER_SIZE:
+        raise AssertionError(len(footer))
+    return b"mock extension payload\0" + footer
+
+
+def _description(
+    target: str,
+    version: str = VERSION,
+    needs_compilation: str = "yes",
+    r_version: str = "4.6.1",
+) -> bytes:
+    return (
+        f"Package: Rduckhts\nVersion: {version}\nNeedsCompilation: {needs_compilation}\n"
+        f"Built: R {r_version}; {target}; 2026-08-04 22:00:00 UTC; unix\n"
+    ).encode("utf-8")
+
+
+def _write_package(
+    directory: Path,
+    *,
+    archive_kind: str,
+    target: str,
+    platform: str,
+    version: str = VERSION,
+    r_version: str = "4.6.1",
+    include_extension: bool = True,
+) -> Path:
+    path = directory / ("package.tar.gz" if archive_kind == "tar" else "package.zip")
+    members = {DESCRIPTION_PATH: _description(target, version, r_version=r_version)}
+    if include_extension:
+        members[EXTENSION_PATH] = _extension(platform, version)
+    if archive_kind == "tar":
+        with tarfile.open(path, "w:gz") as archive:
+            for name, content in members.items():
+                info = tarfile.TarInfo(name)
+                info.size = len(content)
+                archive.addfile(info, io.BytesIO(content))
+    else:
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for name, content in members.items():
+                archive.writestr(name, content)
+    return path
+
+
+class RUniverseArtifactReceiptTests(unittest.TestCase):
+    def test_accepts_linux_arm64_tar_and_returns_exact_footer_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = _write_package(
+                Path(tmp),
+                archive_kind="tar",
+                target="aarch64-unknown-linux-gnu",
+                platform="linux_arm64",
+            )
+            receipt = validate_artifact(package, "linux", VERSION, "4.6.1")
+        self.assertEqual(receipt.platform, "linux_arm64")
+
+    def test_accepts_windows_amd64_zip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = _write_package(
+                Path(tmp),
+                archive_kind="zip",
+                target="x86_64-w64-mingw32",
+                platform="windows_amd64_mingw",
+            )
+            receipt = validate_artifact(package, "win", VERSION, "4.6.1")
+        self.assertEqual(receipt.platform, "windows_amd64_mingw")
+
+    def test_accepts_wasm_receipt_mapping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = _write_package(
+                Path(tmp),
+                archive_kind="tar",
+                target="wasm32-unknown-emscripten",
+                platform="linux_i686_musl",
+                r_version="4.6.0",
+            )
+            receipt = validate_artifact(package, "wasm", VERSION, "4.6.0")
+        self.assertEqual(receipt.platform, "linux_i686_musl")
+
+    def test_rejects_built_and_footer_disagreement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = _write_package(
+                Path(tmp),
+                archive_kind="tar",
+                target="x86_64-pc-linux-gnu",
+                platform="linux_arm64",
+            )
+            with self.assertRaisesRegex(ArtifactValidationError, "resolves to"):
+                validate_artifact(package, "linux", VERSION, "4.6.1")
+
+    def test_rejects_coarse_api_os_disagreement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = _write_package(
+                Path(tmp),
+                archive_kind="zip",
+                target="aarch64-unknown-linux-gnu",
+                platform="linux_arm64",
+            )
+            with self.assertRaisesRegex(ArtifactValidationError, "R-universe os"):
+                validate_artifact(package, "win", VERSION, "4.6.1")
+
+    def test_rejects_missing_extension_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = _write_package(
+                Path(tmp),
+                archive_kind="tar",
+                target="x86_64-pc-linux-gnu",
+                platform="linux_amd64",
+                include_extension=False,
+            )
+            with self.assertRaisesRegex(ArtifactValidationError, "missing"):
+                validate_artifact(package, "linux", VERSION, "4.6.1")
+
+    def test_rejects_package_version_disagreement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = _write_package(
+                Path(tmp),
+                archive_kind="tar",
+                target="x86_64-pc-linux-gnu",
+                platform="linux_amd64",
+                version="1.5.1.9000-0.1.4",
+            )
+            with self.assertRaisesRegex(ArtifactValidationError, "package Version"):
+                validate_artifact(package, "linux", VERSION, "4.6.1")
+
+    def test_rejects_r_version_disagreement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            package = _write_package(
+                Path(tmp),
+                archive_kind="tar",
+                target="x86_64-pc-linux-gnu",
+                platform="linux_amd64",
+                r_version="4.5.3",
+            )
+            with self.assertRaisesRegex(ArtifactValidationError, "Built R version"):
+                validate_artifact(package, "linux", VERSION, "4.6.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/scripts/test_r_universe_artifact.py
+++ b/test/scripts/test_r_universe_artifact.py
@@ -131,6 +131,27 @@ class RUniverseArtifactReceiptTests(unittest.TestCase):
             receipt = validate_artifact(package, "wasm", VERSION, "4.6.0")
         self.assertEqual(receipt.platform, "linux_i686_musl")
 
+    def test_accepts_all_native_architecture_receipts(self) -> None:
+        cases = (
+            ("tar", "x86_64-pc-linux-gnu", "linux_amd64", "linux"),
+            ("zip", "aarch64-unknown-linux-gnu", "linux_arm64", "linux"),
+            ("tar", "x86_64-apple-darwin20", "osx_amd64", "mac"),
+            ("zip", "aarch64-apple-darwin23", "osx_arm64", "mac"),
+            ("tar", "x86_64-w64-mingw32", "windows_amd64_mingw", "win"),
+            ("zip", "aarch64-w64-mingw32", "windows_arm64_mingw", "win"),
+        )
+        for archive_kind, target, platform, api_os in cases:
+            with self.subTest(platform=platform):
+                with tempfile.TemporaryDirectory() as tmp:
+                    package = _write_package(
+                        Path(tmp),
+                        archive_kind=archive_kind,
+                        target=target,
+                        platform=platform,
+                    )
+                    receipt = validate_artifact(package, api_os, VERSION, "4.6.1")
+                self.assertEqual(receipt.platform, platform)
+
     def test_rejects_built_and_footer_disagreement(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             package = _write_package(


### PR DESCRIPTION
## Summary

- validate each R-universe package `DESCRIPTION` `Built` target and R version
- validate the bundled DuckDB extension footer version and platform
- publish artifact names from the exact footer platform instead of coarse API OS labels
- reject missing, contradictory, duplicate, or unsupported architecture receipts
- handle R-universe file URLs whether the API returns a full URL or an identifier
- add mocked tar/zip tests covering Linux, macOS, Windows, and webR receipts

Closes #172.

## Validation

- `python3 test/scripts/test_r_universe_artifact.py`: 9 tests passed
- validated all 14 current R-universe Rduckhts packages and produced 14 receipt-named archives in a local workflow dry run
- `bash -n` and ShellCheck passed for the workflow script
- workflow YAML parsed successfully
- `git diff --check` passed

## Performance

This changes artifact publishing validation and does not touch a measured reader or native hot path. No checked-in benchmark exercises the changed path, so no regression claim is made. The nearest rendered baseline is `benchmarks/benchmark_multi_region_readers.md`, source revision `2abd25645223`: 2,000,000 indexed VCF records yielded 1,625,000 unique output records, using 1 DuckDB thread and 0 htslib decompression threads; median throughput was 18,895,349 unique rows/s for BCF and 5,721,831 unique rows/s for VCF.gz. That workload is not comparable to this change.
