### PR TITLE
Fix reader allocation errors and preserve BAM SAMPLE_ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,15 @@ endif()
 
 message(STATUS "htslib link libs: ${HTSLIB_LINK_LIBS}")
 
+# Test-only copied-API interposition; never linked into the extension/package.
+if(UNIX AND NOT DUCKDB_WASM_EXTENSION)
+    add_library(duckhts_reader_alloc_probe SHARED EXCLUDE_FROM_ALL test/scripts/reader_alloc_probe.c)
+    target_compile_features(duckhts_reader_alloc_probe PRIVATE c_std_11)
+    target_compile_options(duckhts_reader_alloc_probe PRIVATE -fvisibility=default)
+    target_include_directories(duckhts_reader_alloc_probe PRIVATE duckdb_capi src/include)
+    target_link_libraries(duckhts_reader_alloc_probe PRIVATE ${CMAKE_DL_LIBS})
+endif()
+
 # Host-neutral region parsing probe: real HTSlib, no DuckDB headers or runtime.
 if(NOT DUCKDB_WASM_EXTENSION)
     add_executable(duckhts_region_list_test EXCLUDE_FROM_ALL test/scripts/region_list_test.c)

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ test: test_debug
 test_debug: test-cache-paths test-duckvep-kernel test-simd-kernels test-liftover-property test-liftover-fuzz-debug test-sqllogictest-debug
 test_release: test-cache-paths test-duckvep-kernel test-simd-kernels test-liftover-property test-liftover-fuzz test-bcftools-filter-recovery test-sqllogictest-release
 test_release: test-reference-cache
-ifeq ($(shell uname -s),Linux)
+ifneq ($(filter linux_%,$(or $(DUCKDB_PLATFORM),$(shell sed -n '1p' configure/platform.txt 2>/dev/null))),)
 test_release: test-reader-alloc
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -146,17 +146,22 @@ ifneq ($(filter linux_%,$(or $(DUCKDB_PLATFORM),$(shell sed -n '1p' configure/pl
 test_release: test-reader-alloc
 endif
 
-.PHONY: test-reader-alloc
-test-reader-alloc:
-	cmake --build cmake_build/release --target duckhts_reader_alloc_probe
-	./configure/venv/bin/python3 test/scripts/reader_alloc_test.py \
-		--extension build/release/duckhts.duckdb_extension \
-		--probe cmake_build/release/libduckhts_reader_alloc_probe.so
+# Distribution CI tests the same binary inside and outside Docker. Its CMake
+# cache contains container-absolute paths, so build this host-only shim afresh.
+define run_reader_alloc_test
+	@set -e; tmp=$$(mktemp -d); trap 'rm -rf "$$tmp"' EXIT; \
+		$(CC) -std=c11 -O1 -g -Wall -Wextra -Werror -fPIC -shared \
+			-Iduckdb_capi -Isrc/include test/scripts/reader_alloc_probe.c -ldl \
+			-o "$$tmp/reader_alloc_probe.so"; \
+		$(1) "$$tmp/reader_alloc_probe.so"
+endef
 
-.PHONY: test-reader-alloc-r
+.PHONY: test-reader-alloc test-reader-alloc-r
+test-reader-alloc:
+	$(call run_reader_alloc_test,./configure/venv/bin/python3 test/scripts/reader_alloc_test.py --extension build/release/duckhts.duckdb_extension --probe)
+
 test-reader-alloc-r:
-	cmake --build cmake_build/release --target duckhts_reader_alloc_probe
-	Rscript test/scripts/reader_alloc_test.R cmake_build/release/libduckhts_reader_alloc_probe.so
+	$(call run_reader_alloc_test,Rscript test/scripts/reader_alloc_test.R)
 
 .PHONY: test-region-list
 test-region-list:

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,21 @@ test: test_debug
 test_debug: test-cache-paths test-duckvep-kernel test-simd-kernels test-liftover-property test-liftover-fuzz-debug test-sqllogictest-debug
 test_release: test-cache-paths test-duckvep-kernel test-simd-kernels test-liftover-property test-liftover-fuzz test-bcftools-filter-recovery test-sqllogictest-release
 test_release: test-reference-cache
+ifeq ($(shell uname -s),Linux)
+test_release: test-reader-alloc
+endif
+
+.PHONY: test-reader-alloc
+test-reader-alloc:
+	cmake --build cmake_build/release --target duckhts_reader_alloc_probe
+	./configure/venv/bin/python3 test/scripts/reader_alloc_test.py \
+		--extension build/release/duckhts.duckdb_extension \
+		--probe cmake_build/release/libduckhts_reader_alloc_probe.so
+
+.PHONY: test-reader-alloc-r
+test-reader-alloc-r:
+	cmake --build cmake_build/release --target duckhts_reader_alloc_probe
+	Rscript test/scripts/reader_alloc_test.R cmake_build/release/libduckhts_reader_alloc_probe.so
 
 .PHONY: test-region-list
 test-region-list:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 # DuckHTS Extension News
 
 # duckhts 1.5.1.9000
+- report allocation failures while constructing BAM/BCF/FASTA/FASTQ readers
+  instead of crashing the host or publishing incomplete BCF schemas. Check
+  array sizes and make partial cleanup safe, including FORMAT projection groups.
+  Remove the redundant BAM sample-string copy and report failed SAMPLE_ID
+  cache/HTSlib lookups instead of silently substituting NULL; genuinely absent
+  samples remain NULL. Add isolated first-party allocation-failure/recovery tests
+
 - reject empty region-list items and malformed known-contig intervals instead
   of silently widening or partially executing a request. Share one checked,
   host-neutral list parser across BAM, BCF, FASTA, and tabix readers; retain

--- a/benchmarks/benchmark_bam_tail_scan.Rmd
+++ b/benchmarks/benchmark_bam_tail_scan.Rmd
@@ -1,11 +1,11 @@
 ---
-title: "Automatic BAM tail ownership: small-fixture scan cost"
+title: "Automatic BAM full-file scan: small-fixture cost"
 output:
   github_document:
     html_preview: false
 ---
 
-This compares the automatic BAM scan before and after the no-coordinate tail fix,
+This compares automatic BAM scans at two named reader revisions,
 using the existing `benchmark_simd_bam_gc.py` workload on its committed nanopore
 fixture. It exercises many empty contig claims and full `SEQ` decoding, but this
 186-record fixture is dominated by setup cost: it is not a WGS throughput benchmark.
@@ -23,7 +23,7 @@ Remote I/O, large-input throughput, and CRAM performance remain unmeasured.
 ## Reproduction and identity
 
 Build each named source revision separately. Set `BAM_SCAN_BASELINE_EXTENSION` to
-the pre-fix binary, `BAM_SCAN_BASELINE_REVISION` to its revision, then render this
+the baseline binary, `BAM_SCAN_BASELINE_REVISION` to its revision, then render this
 report from the repository root. `DUCKHTS_EXTENSION` selects the candidate binary;
 `PYTHON` selects the Python environment with DuckDB installed.
 

--- a/benchmarks/benchmark_bam_tail_scan.md
+++ b/benchmarks/benchmark_bam_tail_scan.md
@@ -1,13 +1,13 @@
-Automatic BAM tail ownership: small-fixture scan cost
+Automatic BAM full-file scan: small-fixture cost
 ================
 
-This compares the automatic BAM scan before and after the no-coordinate
-tail fix, using the existing `benchmark_simd_bam_gc.py` workload on its
-committed nanopore fixture. It exercises many empty contig claims and
-full `SEQ` decoding, but this 186-record fixture is dominated by setup
-cost: it is not a WGS throughput benchmark. There are no unplaced reads
-in this performance input, so both builds do equal work. The separate
-SQL/R regression corpus tests retained no-coordinate records, physical
+This compares automatic BAM scans at two named reader revisions, using
+the existing `benchmark_simd_bam_gc.py` workload on its committed
+nanopore fixture. It exercises many empty contig claims and full `SEQ`
+decoding, but this 186-record fixture is dominated by setup cost: it is
+not a WGS throughput benchmark. There are no unplaced reads in this
+performance input, so both builds do equal work. The separate SQL/R
+regression corpus tests retained no-coordinate records, physical
 duplicates, BAI/CSI, CRAM, and output chunks.
 
 The nearest checked-in report is
@@ -21,32 +21,32 @@ throughput, and CRAM performance remain unmeasured.
 ## Reproduction and identity
 
 Build each named source revision separately. Set
-`BAM_SCAN_BASELINE_EXTENSION` to the pre-fix binary,
+`BAM_SCAN_BASELINE_EXTENSION` to the baseline binary,
 `BAM_SCAN_BASELINE_REVISION` to its revision, then render this report
 from the repository root. `DUCKHTS_EXTENSION` selects the candidate
 binary; `PYTHON` selects the Python environment with DuckDB installed.
 
 | property             | value                                                                      |
 |:---------------------|:---------------------------------------------------------------------------|
-| baseline revision    | 3878b976380bd4d3816d4fc416a78b59eaf0580f                                   |
-| candidate revision   | 67db30ac9dc40d0de4f6bb8ae55c6cfa3ea48011                                   |
-| candidate src tree   | 352c4c79b2eb84b5ef7847e316420b8f4a0a238c                                   |
-| baseline binary MD5  | 92aef5253e9920fe0b59df156412991d                                           |
-| candidate binary MD5 | df999b32c0759ea8a9fa50b4ae0cecd7                                           |
+| baseline revision    | da5daa2cdd75aa9a920bf6a71f18174661b15198                                   |
+| candidate revision   | 05fcdfdfcb32eb94a987d946e65d377040644c1a                                   |
+| candidate src tree   | b7e5c3bbd984e0e339780d71d6324098622d2fa5                                   |
+| baseline binary MD5  | 5bfcfbbd4d206288713427cb9d402806                                           |
+| candidate binary MD5 | ec990d55a894db4fd760d84b7c66026b                                           |
 | input                | test/data/nanopore.bam                                                     |
 | input MD5            | 850dc34ada8d7023ee7146c7953da90b                                           |
 | input bytes          | 283081                                                                     |
 | HTSlib               | 1.24                                                                       |
 | host                 | Linux                                                                      |
-| CPU affinity         | pid 366859’s current affinity list: 0,2,4,6                                |
+| CPU affinity         | pid 595985’s current affinity list: 0,2,4,6                                |
 | repetitions          | 9 per build/thread setting after warm-up; fresh Python process per setting |
 
 | build     | duckdb_workers | htslib_workers_per_handle | input_records | decoded_sequence_rows | input_bases | sql_output_rows |   gc_sum | backend | median_seconds | min_seconds | max_seconds |
 |:----------|---------------:|--------------------------:|--------------:|----------------------:|------------:|----------------:|---------:|:--------|---------------:|------------:|------------:|
-| baseline  |              1 |                         2 |           186 |                   186 |      249110 |               1 | 75.87703 | avx2    |       0.001314 |    0.001199 |    0.001399 |
-| candidate |              1 |                         2 |           186 |                   186 |      249110 |               1 | 75.87703 | avx2    |       0.001340 |    0.001274 |    0.001407 |
-| baseline  |              4 |                         2 |           186 |                   186 |      249110 |               1 | 75.87703 | avx2    |       0.001739 |    0.001664 |    0.002049 |
-| candidate |              4 |                         2 |           186 |                   186 |      249110 |               1 | 75.87703 | avx2    |       0.001810 |    0.001654 |    0.005563 |
+| baseline  |              1 |                         2 |           186 |                   186 |      249110 |               1 | 75.87703 | avx2    |       0.001684 |    0.001316 |    0.012549 |
+| candidate |              1 |                         2 |           186 |                   186 |      249110 |               1 | 75.87703 | avx2    |       0.001561 |    0.001486 |    0.001701 |
+| baseline  |              4 |                         2 |           186 |                   186 |      249110 |               1 | 75.87703 | avx2    |       0.002069 |    0.001731 |    0.002444 |
+| candidate |              4 |                         2 |           186 |                   186 |      249110 |               1 | 75.87703 | avx2    |       0.002239 |    0.001794 |    0.004775 |
 
 Each query scans 186 BAM records, materializes their sequences into
 DuckDB vectors, and returns one aggregate row containing the read count,

--- a/benchmarks/benchmark_bcf_record_cache.Rmd
+++ b/benchmarks/benchmark_bcf_record_cache.Rmd
@@ -22,8 +22,11 @@ Rscript -e 'rmarkdown::render("benchmarks/benchmark_bcf_record_cache.Rmd", knit_
 ```
 
 The earlier `benchmark_bcf_record_cache.md` records the experiment at its named
-source revisions. Preserve that report when measuring retirement: render this
-Rmd with `output_file = "benchmark_bcf_reader_retirement.md"`. Set
+source revisions. Preserve historical reports when measuring subsequent changes:
+render this Rmd with a change-specific output file (for allocation-error handling,
+`output_file = "benchmark_reader_allocations.md"`). The paired pre-change binary
+provides the identical-workload baseline. This workload exercises BCF construction
+and materialization, not BAM SAMPLE_ID caching or FASTA/FASTQ throughput. Set
 `BCF_CACHE_READERS=read_bcf,read_bcf_v2` only to reproduce the historical comparison
 with two old binaries that both expose the experimental reader.
 

--- a/benchmarks/benchmark_reader_allocations.md
+++ b/benchmarks/benchmark_reader_allocations.md
@@ -1,0 +1,136 @@
+DuckHTS BCF record-cache ownership
+================
+
+<!-- Reports are generated from benchmark_bcf_record_cache.Rmd. -->
+
+This paired workload materializes **every declared column** of the
+registered GIAB HG002 GRCh38 NIST v4.2.1 benchmark VCF with `read_bcf`,
+in wide and tidy form. The file has one sample, so input records and
+output rows have the same denominator. This exercises typed INFO, GT,
+and FORMAT decoding across many output chunks, not multi-sample
+expansion or CSQ.
+
+Stage `variantkey_giab_hg002_v421` explicitly with the `duckhtsbench`
+`duckhts_bench_fetch()` helper before running; rendering never downloads
+data. Then build both revisions with the same toolchain and run from the
+repo root:
+
+``` sh
+BCF_CACHE_BASELINE_EXTENSION=/path/to/baseline/duckhts.duckdb_extension \
+BCF_CACHE_BASELINE_REV=<commit> \
+Rscript -e 'rmarkdown::render("benchmarks/benchmark_bcf_record_cache.Rmd", knit_root_dir=getwd())'
+```
+
+The earlier `benchmark_bcf_record_cache.md` records the experiment at
+its named source revisions. Preserve historical reports when measuring
+subsequent changes: render this Rmd with a change-specific output file
+(for allocation-error handling,
+`output_file = "benchmark_reader_allocations.md"`). The paired
+pre-change binary provides the identical-workload baseline. This
+workload exercises BCF construction and materialization, not BAM
+SAMPLE_ID caching or FASTA/FASTQ throughput. Set
+`BCF_CACHE_READERS=read_bcf,read_bcf_v2` only to reproduce the
+historical comparison with two old binaries that both expose the
+experimental reader.
+
+## Revisions, input, and environment
+
+    ##   revision                                   commit
+    ##   baseline da5daa2cdd75aa9a920bf6a71f18174661b15198
+    ##  candidate 05fcdfdfcb32eb94a987d946e65d377040644c1a
+    ##                                  src_tree                    extension_md5
+    ##  37670e4dcad48c2828879054fabf4a3dbc1e8f40 5bfcfbbd4d206288713427cb9d402806
+    ##  b7e5c3bbd984e0e339780d71d6324098622d2fa5 ec990d55a894db4fd760d84b7c66026b
+
+    ## Artifact: variantkey_giab_hg002_v421; registered bytes: 156252944
+
+    ## Observed input MD5: dc750b3807d4af1f7ffec852e9c2f771
+
+    ## Input records: 4048342 ; sample: HG002; output rows per scan: 4048342
+
+    ## DuckDB threads: 1; sequential scan handles: 1; HTSlib decompression workers: 0
+
+    ## Measured repetitions per reader/mode/revision: 3
+
+    ## R: R version 4.6.0 (2026-04-24) ; DuckDB: 1.5.3
+
+    ## Linux 6.8.0-78-generic x86_64 GNU/Linux
+
+    ## Ubuntu clang version 18.1.3 (1ubuntu1)
+
+    ## bcftools 1.23.1-70-g6dbd8fef
+    ## Using htslib 1.22.1
+
+    ## pid 596789's current affinity list: 0,2,4,6
+
+    ## Model name:                           13th Gen Intel(R) Core(TM) i5-13500 BIOS Model name:                      13th Gen Intel(R) Core(TM) i5-13500 To Be Filled By O.E.M. CPU @ 2.4GHz
+
+## Full typed materialization
+
+Elapsed and user + system CPU times include binding, initialization,
+VCF/BGZF decoding, typed vectors, and `CREATE TABLE AS` materialization.
+Every repetition uses a fresh R/DuckDB process. Startup, staging,
+independent counting, checksum validation, Parquet snapshot writing, and
+exact comparison are outside timing. The OS page cache is warm. RSS is
+the whole-process high-water mark immediately after materialization, not
+an allocation count or cache-only measurement.
+
+    ##  mode   reader  revision elapsed    cpu peak_rss_kib input_records output_rows
+    ##  tidy read_bcf  baseline  15.339 15.339      3792776       4048342     4048342
+    ##  wide read_bcf  baseline  16.977 16.965      3748444       4048342     4048342
+    ##  tidy read_bcf candidate  14.797 14.797      3792240       4048342     4048342
+    ##  wide read_bcf candidate  14.592 14.592      3748004       4048342     4048342
+    ##  rows_per_second
+    ##           263925
+    ##           238460
+    ##           273592
+    ##           277436
+
+    ##  mode   reader  revision run    rows columns elapsed    cpu
+    ##  wide read_bcf  baseline   1 4048342      29  16.977 16.965
+    ##  wide read_bcf candidate   1 4048342      29  14.518 14.516
+    ##  wide read_bcf candidate   2 4048342      29  15.540 15.484
+    ##  wide read_bcf  baseline   2 4048342      29  15.478 15.478
+    ##  wide read_bcf  baseline   3 4048342      29  17.819 17.780
+    ##  wide read_bcf candidate   3 4048342      29  14.592 14.592
+    ##  tidy read_bcf  baseline   1 4048342      30  15.371 15.372
+    ##  tidy read_bcf candidate   1 4048342      30  14.777 14.777
+    ##  tidy read_bcf candidate   2 4048342      30  14.797 14.797
+    ##  tidy read_bcf  baseline   2 4048342      30  15.339 15.339
+    ##  tidy read_bcf  baseline   3 4048342      30  15.298 15.297
+    ##  tidy read_bcf candidate   3 4048342      30  14.910 14.909
+
+## Output agreement and scope
+
+    ##  mode              reference                compared different_rows
+    ##  wide wide_read_bcf_baseline wide_read_bcf_candidate              0
+    ##  tidy tidy_read_bcf_baseline tidy_read_bcf_candidate              0
+
+    ##  mode    rows columns                   checksum
+    ##  wide 4048342      29 37346610631881826082171150
+    ##  tidy 4048342      30 37336419453416803666352226
+
+Each first-run snapshot is compared against the pre-change `read_bcf`
+output with `EXCEPT ALL` in both directions. Every repetition also
+checks the independent record count and a sum of hashes covering every
+materialized field. Hash agreement alone is not an exact oracle; the
+separate first-run comparisons check complete typed row multisets. The
+registry pins the supplier byte count; the input MD5 above is observed
+at measurement time, not a supplier-authenticated checksum.
+
+The earlier [appender contig report](benchmark_bcf_appender_contigs.md)
+exercises a narrow scalar appender with different data and scheduling.
+It is not an identical-workload baseline; the paired pre-change build
+here supplies that baseline. This report does not measure indexed or
+remote scans, appender pipelining, many-sample throughput, CSQ parsing
+throughput, or bounded/static allocation. It establishes neither
+universal performance parity nor a fastest-reader claim.
+
+The independent SQL/R regression fixtures separately exercise two-sample
+CSQ replication, all 2,053 sample rows of a record crossing an output
+chunk, missing annotations and FORMAT values, growing list/string
+buffers, and changing ploidy. This workload has no CSQ: its timings do
+not establish annotation correctness. The paired revisions above
+identify the actual comparison; experimental API retirement and
+canonical record-cache correctness are separate changes. No incorrect
+annotation output is accepted as a throughput oracle.

--- a/r/Rduckhts/NEWS.md
+++ b/r/Rduckhts/NEWS.md
@@ -1,5 +1,10 @@
 
 # Rduckhts 1.5.1.9000-0.1.5
+- make bundled BAM/BCF/FASTA/FASTQ reader-state allocation failures query errors
+  with safe partial cleanup, rather than host crashes or incomplete BCF schemas.
+  BAM SAMPLE_ID lookup/cache failures now raise errors instead of losing sample
+  values; genuinely missing sample annotations still return NA through DBI
+
 - reject empty region-list items in bundled BAM/BCF/FASTA/tabix readers and
   malformed known-contig BAM/BCF/tabix intervals. Region-list parse failures no
   longer become full-file or partial scans; NULL/empty-string selection still

--- a/r/Rduckhts/inst/duckhts_extension/bam_reader.c
+++ b/r/Rduckhts/inst/duckhts_extension/bam_reader.c
@@ -36,6 +36,7 @@ DUCKDB_EXTENSION_EXTERN
 #include <htslib/kstring.h>
 
 #include "include/hts_io_tuning.h"
+#include "include/duckdb_alloc.h"
 #include "include/region_list.h"
 #include "include/seq_encoding.h"
 #include "include/quality_encoding.h"
@@ -290,7 +291,7 @@ typedef struct {
 
     /* Read group caching */
     char *last_rg_id;
-    char *last_sample_id;
+    int has_sample;
     kstring_t rg_tmp;
 } bam_local_init_data_t;
 
@@ -324,8 +325,7 @@ static void destroy_bam_local(void *data) {
     if (l->column_ids) duckdb_free(l->column_ids);
     if (l->seq_buf) free(l->seq_buf);
     if (l->qual_buf) free(l->qual_buf);
-    if (l->last_rg_id) free(l->last_rg_id);
-    if (l->last_sample_id) free(l->last_sample_id);
+    if (l->last_rg_id) duckdb_free(l->last_rg_id);
     ks_free(&l->rg_tmp);
     ks_free(&l->cigar_tmp);
     ks_free(&l->aux_tmp);
@@ -345,7 +345,8 @@ static int bam_region_name2id(void *hdr, const char *name) {
  * ================================================================ */
 
 static int ensure_seq_buf(bam_local_init_data_t *l, int seq_len) {
-    size_t need = (size_t)(seq_len + 1);
+    if (seq_len < 0 || (uint64_t)seq_len >= SIZE_MAX / 2) return 0;
+    size_t need = (size_t)seq_len + 1;
     if (need > l->seq_buf_cap) {
         size_t new_cap = need * 2;
         char *new_seq = (char *)realloc(l->seq_buf, new_cap);
@@ -525,8 +526,17 @@ static void bam_read_bind(duckdb_bind_info info) {
         return;
     }
 
-    bam_bind_data_t *bind = (bam_bind_data_t *)duckdb_malloc(sizeof(bam_bind_data_t));
-    memset(bind, 0, sizeof(bam_bind_data_t));
+    bam_bind_data_t *bind = duckhts_alloc_array(1, sizeof(*bind));
+    if (!bind) {
+        duckdb_bind_set_error(info, "read_bam: out of memory allocating bind state");
+        sam_hdr_destroy(hdr);
+        sam_close(fp);
+        duckdb_free(file_path);
+        if (index_path) duckdb_free(index_path);
+        if (region) duckdb_free(region);
+        if (reference) duckdb_free(reference);
+        return;
+    }
     bind->file_path = file_path;
     bind->index_path = index_path;
     bind->reference = reference;
@@ -722,9 +732,11 @@ static void bam_read_global_init(duckdb_init_info info) {
     bam_bind_data_t *bind = (bam_bind_data_t *)duckdb_init_get_bind_data(info);
     idx_t column_count = duckdb_init_get_column_count(info);
 
-    bam_global_init_data_t *global = (bam_global_init_data_t *)duckdb_malloc(
-        sizeof(bam_global_init_data_t));
-    memset(global, 0, sizeof(bam_global_init_data_t));
+    bam_global_init_data_t *global = duckhts_alloc_array(1, sizeof(*global));
+    if (!global) {
+        duckdb_init_set_error(info, "read_bam: out of memory allocating global state");
+        return;
+    }
 
     global->current_partition = 0;
     global->has_region = (bind->n_regions > 0);
@@ -756,13 +768,20 @@ static void bam_read_global_init(duckdb_init_info info) {
 static void bam_read_local_init(duckdb_init_info info) {
     bam_bind_data_t *bind = (bam_bind_data_t *)duckdb_init_get_bind_data(info);
 
-    bam_local_init_data_t *local = (bam_local_init_data_t *)duckdb_malloc(
-        sizeof(bam_local_init_data_t));
-    memset(local, 0, sizeof(bam_local_init_data_t));
+    bam_local_init_data_t *local = duckhts_alloc_array(1, sizeof(*local));
+    if (!local) {
+        duckdb_init_set_error(info, "read_bam: out of memory allocating worker state");
+        return;
+    }
 
     local->column_count = duckdb_init_get_column_count(info);
     if (local->column_count > 0) {
-        local->column_ids = (idx_t *)duckdb_malloc(sizeof(idx_t) * local->column_count);
+        local->column_ids = duckhts_alloc_array(local->column_count, sizeof(*local->column_ids));
+        if (!local->column_ids) {
+            duckdb_init_set_error(info, "read_bam: out of memory allocating projected columns");
+            destroy_bam_local(local);
+            return;
+        }
         for (idx_t i = 0; i < local->column_count; i++) {
             local->column_ids[i] = duckdb_init_get_column_index(info, i);
             if (local->column_ids[i] == BAM_COL_SEQ || local->column_ids[i] == BAM_COL_QUAL) {
@@ -790,7 +809,7 @@ static void bam_read_local_init(duckdb_init_info info) {
     local->fp = sam_open(bind->file_path, "r");
     if (!local->fp) {
         duckdb_init_set_error(info, "Failed to open SAM/BAM/CRAM file");
-        duckdb_free(local);
+        destroy_bam_local(local);
         return;
     }
     duckhts_apply_remote_hts_tuning(
@@ -804,8 +823,7 @@ static void bam_read_local_init(duckdb_init_info info) {
     if (bind->reference) {
         if (hts_set_opt(local->fp, CRAM_OPT_REFERENCE, bind->reference) < 0) {
             duckdb_init_set_error(info, "Failed to set CRAM reference");
-            sam_close(local->fp);
-            duckdb_free(local);
+            destroy_bam_local(local);
             return;
         }
     }
@@ -822,17 +840,18 @@ static void bam_read_local_init(duckdb_init_info info) {
     /* Read header — each thread needs its own copy */
     local->hdr = sam_hdr_read(local->fp);
     if (!local->hdr) {
-        sam_close(local->fp); local->fp = NULL;
         duckdb_init_set_error(info, "Failed to read SAM/BAM/CRAM header");
-        duckdb_free(local);
+        destroy_bam_local(local);
         return;
     }
 
     /* Allocate a reusable bam1_t record */
     local->rec = bam_init1();
-    local->rg_tmp.l = 0;
-    local->rg_tmp.m = 0;
-    local->rg_tmp.s = NULL;
+    if (!local->rec) {
+        duckdb_init_set_error(info, "read_bam: out of memory allocating alignment record");
+        destroy_bam_local(local);
+        return;
+    }
 
     /* Load index if needed for parallel scanning or region queries */
     if (is_parallel || bind->n_regions > 0) {
@@ -1192,18 +1211,29 @@ static void bam_read_function(duckdb_function_info info, duckdb_data_chunk outpu
                     break;
                 }
                 if (!local->last_rg_id || strcmp(local->last_rg_id, rg) != 0) {
-                    free(local->last_rg_id);
-                    free(local->last_sample_id);
-                    local->last_rg_id = strdup(rg);
-                    local->last_sample_id = NULL;
-                    local->rg_tmp.l = 0;
-                    if (sam_hdr_find_tag_id(local->hdr, "RG", "ID", rg, "SM", &local->rg_tmp) == 0 &&
-                        local->rg_tmp.s && local->rg_tmp.l > 0) {
-                        local->last_sample_id = strdup(local->rg_tmp.s);
+                    char *next_rg = duckhts_copy_string(rg);
+                    if (!next_rg) {
+                        duckdb_function_set_error(info, "read_bam: out of memory caching SAMPLE_ID read group");
+                        local->done = 1;
+                        duckdb_data_chunk_set_size(output, 0);
+                        return;
                     }
+                    local->rg_tmp.l = 0;
+                    int status = sam_hdr_find_tag_id(local->hdr, "RG", "ID", rg, "SM", &local->rg_tmp);
+                    if (status < -1) {
+                        duckdb_free(next_rg);
+                        duckdb_function_set_error(info, "read_bam: HTSlib failed to resolve SAMPLE_ID");
+                        local->done = 1;
+                        duckdb_data_chunk_set_size(output, 0);
+                        return;
+                    }
+                    if (local->last_rg_id) duckdb_free(local->last_rg_id);
+                    local->last_rg_id = next_rg;
+                    local->has_sample = status == 0 && local->rg_tmp.l > 0;
                 }
-                if (local->last_sample_id) {
-                    duckdb_vector_assign_string_element(vec, row_count, local->last_sample_id);
+                if (local->has_sample) {
+                    /* DuckDB copies the worker-owned lookup string. */
+                    duckdb_vector_assign_string_element_len(vec, row_count, local->rg_tmp.s, local->rg_tmp.l);
                 } else {
                     set_null(vec, row_count);
                 }

--- a/r/Rduckhts/inst/duckhts_extension/bcf_reader.c
+++ b/r/Rduckhts/inst/duckhts_extension/bcf_reader.c
@@ -50,6 +50,7 @@ DUCKDB_EXTENSION_EXTERN
 #include <htslib/kstring.h>
 
 #include "include/hts_io_tuning.h"
+#include "include/duckdb_alloc.h"
 #include "include/region_list.h"
 
 // =============================================================================
@@ -428,48 +429,33 @@ static int bcf_decode_cache_init(bcf_init_data_t *init, const bcf_bind_data_t *b
 
     if (bind->n_format_fields > 0) {
         size_t nfmt = (size_t)bind->n_format_fields;
-        init->fmt_loaded = (int *)duckdb_malloc(nfmt * sizeof(int));
-        init->fmt_ret = (int *)duckdb_malloc(nfmt * sizeof(int));
-        init->fmt_n_values = (int *)duckdb_malloc(nfmt * sizeof(int));
-        init->fmt_i32 = (int32_t **)duckdb_malloc(nfmt * sizeof(int32_t *));
-        init->fmt_f32 = (float **)duckdb_malloc(nfmt * sizeof(float *));
-        init->fmt_str = (char ***)duckdb_malloc(nfmt * sizeof(char **));
-        /* Cleanup must see only initialized element pointers after any
-         * allocation failure, including a partially constructed cache. */
-        if (init->fmt_i32) memset(init->fmt_i32, 0, nfmt * sizeof(int32_t *));
-        if (init->fmt_f32) memset(init->fmt_f32, 0, nfmt * sizeof(float *));
-        if (init->fmt_str) memset(init->fmt_str, 0, nfmt * sizeof(char **));
+        init->fmt_loaded = duckhts_alloc_array(nfmt, sizeof(*init->fmt_loaded));
+        init->fmt_ret = duckhts_alloc_array(nfmt, sizeof(*init->fmt_ret));
+        init->fmt_n_values = duckhts_alloc_array(nfmt, sizeof(*init->fmt_n_values));
+        init->fmt_i32 = duckhts_alloc_array(nfmt, sizeof(*init->fmt_i32));
+        init->fmt_f32 = duckhts_alloc_array(nfmt, sizeof(*init->fmt_f32));
+        init->fmt_str = duckhts_alloc_array(nfmt, sizeof(*init->fmt_str));
         if (!init->fmt_loaded || !init->fmt_ret || !init->fmt_n_values ||
             !init->fmt_i32 || !init->fmt_f32 || !init->fmt_str) {
             bcf_decode_cache_free(init);
             return 0;
         }
-        memset(init->fmt_loaded, 0, nfmt * sizeof(int));
-        memset(init->fmt_ret, 0, nfmt * sizeof(int));
-        memset(init->fmt_n_values, 0, nfmt * sizeof(int));
     }
 
     if (bind->n_info_fields > 0) {
         size_t ninfo = (size_t)bind->n_info_fields;
-        init->info_loaded = (int *)duckdb_malloc(ninfo * sizeof(int));
-        init->info_ret = (int *)duckdb_malloc(ninfo * sizeof(int));
-        init->info_n_values = (int *)duckdb_malloc(ninfo * sizeof(int));
-        init->info_flag = (int *)duckdb_malloc(ninfo * sizeof(int));
-        init->info_i32 = (int32_t **)duckdb_malloc(ninfo * sizeof(int32_t *));
-        init->info_f32 = (float **)duckdb_malloc(ninfo * sizeof(float *));
-        init->info_str = (char **)duckdb_malloc(ninfo * sizeof(char *));
-        if (init->info_i32) memset(init->info_i32, 0, ninfo * sizeof(int32_t *));
-        if (init->info_f32) memset(init->info_f32, 0, ninfo * sizeof(float *));
-        if (init->info_str) memset(init->info_str, 0, ninfo * sizeof(char *));
+        init->info_loaded = duckhts_alloc_array(ninfo, sizeof(*init->info_loaded));
+        init->info_ret = duckhts_alloc_array(ninfo, sizeof(*init->info_ret));
+        init->info_n_values = duckhts_alloc_array(ninfo, sizeof(*init->info_n_values));
+        init->info_flag = duckhts_alloc_array(ninfo, sizeof(*init->info_flag));
+        init->info_i32 = duckhts_alloc_array(ninfo, sizeof(*init->info_i32));
+        init->info_f32 = duckhts_alloc_array(ninfo, sizeof(*init->info_f32));
+        init->info_str = duckhts_alloc_array(ninfo, sizeof(*init->info_str));
         if (!init->info_loaded || !init->info_ret || !init->info_n_values ||
             !init->info_flag || !init->info_i32 || !init->info_f32 || !init->info_str) {
             bcf_decode_cache_free(init);
             return 0;
         }
-        memset(init->info_loaded, 0, ninfo * sizeof(int));
-        memset(init->info_ret, 0, ninfo * sizeof(int));
-        memset(init->info_n_values, 0, ninfo * sizeof(int));
-        memset(init->info_flag, 0, ninfo * sizeof(int));
     }
 
     return 1;
@@ -506,14 +492,6 @@ static void destroy_init_data(void* data) {
 // =============================================================================
 // String Utilities
 // =============================================================================
-
-static char* strdup_duckdb(const char* s) {
-    if (!s) return NULL;
-    size_t len = strlen(s) + 1;
-    char* copy = (char*)duckdb_malloc(len);
-    if (copy) memcpy(copy, s, len);
-    return copy;
-}
 
 static int bcf_region_name2id(void *hdr, const char *name) {
     return bcf_hdr_name2id((bcf_hdr_t *)hdr, name);
@@ -873,13 +851,11 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
 
     const char *reader_name = "read_bcf";
 
-    local->projected_cols = (bcf_projected_col_t *)duckdb_malloc(
-        (size_t)local->column_count * sizeof(bcf_projected_col_t));
+    local->projected_cols = duckhts_alloc_array(local->column_count, sizeof(*local->projected_cols));
     if (!local->projected_cols) {
         snprintf(err, err_size, "%s: out of memory allocating projected column descriptors", reader_name);
         return 0;
     }
-    memset(local->projected_cols, 0, (size_t)local->column_count * sizeof(bcf_projected_col_t));
 
     int tidy_mode = bind->tidy_format && bind->n_samples > 0;
 
@@ -987,12 +963,11 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
 
     int *format_counts = NULL;
     if (bind->n_format_fields > 0) {
-        format_counts = (int *)duckdb_malloc((size_t)bind->n_format_fields * sizeof(int));
+        format_counts = duckhts_alloc_array(bind->n_format_fields, sizeof(*format_counts));
         if (!format_counts) {
             snprintf(err, err_size, "%s: out of memory allocating FORMAT projection counts", reader_name);
             return 0;
         }
-        memset(format_counts, 0, (size_t)bind->n_format_fields * sizeof(int));
     }
 
     for (idx_t i = 0; i < local->column_count; i++) {
@@ -1010,8 +985,7 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
     }
 
     if (local->site_column_count > 0) {
-        local->site_column_indices = (idx_t *)duckdb_malloc(
-            (size_t)local->site_column_count * sizeof(idx_t));
+        local->site_column_indices = duckhts_alloc_array(local->site_column_count, sizeof(*local->site_column_indices));
         if (!local->site_column_indices) {
             snprintf(err, err_size, "%s: out of memory allocating site column descriptors", reader_name);
             if (format_counts) duckdb_free(format_counts);
@@ -1022,10 +996,9 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
     int *format_group_for_field = NULL;
     int *format_group_offsets = NULL;
     if (local->n_format_groups > 0) {
-        local->format_groups = (bcf_format_group_t *)duckdb_malloc(
-            (size_t)local->n_format_groups * sizeof(bcf_format_group_t));
-        format_group_for_field = (int *)duckdb_malloc((size_t)bind->n_format_fields * sizeof(int));
-        format_group_offsets = (int *)duckdb_malloc((size_t)local->n_format_groups * sizeof(int));
+        local->format_groups = duckhts_alloc_array(local->n_format_groups, sizeof(*local->format_groups));
+        format_group_for_field = duckhts_alloc_array(bind->n_format_fields, sizeof(*format_group_for_field));
+        format_group_offsets = duckhts_alloc_array(local->n_format_groups, sizeof(*format_group_offsets));
         if (!local->format_groups || !format_group_for_field || !format_group_offsets) {
             snprintf(err, err_size, "%s: out of memory allocating FORMAT projection groups", reader_name);
             if (format_counts) duckdb_free(format_counts);
@@ -1033,11 +1006,9 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
             if (format_group_offsets) duckdb_free(format_group_offsets);
             return 0;
         }
-        memset(local->format_groups, 0, (size_t)local->n_format_groups * sizeof(bcf_format_group_t));
         for (int i = 0; i < bind->n_format_fields; i++) {
             format_group_for_field[i] = -1;
         }
-        memset(format_group_offsets, 0, (size_t)local->n_format_groups * sizeof(int));
 
         int group_idx = 0;
         for (int field_idx = 0; field_idx < bind->n_format_fields; field_idx++) {
@@ -1048,8 +1019,7 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
             group->field_idx = field_idx;
             group->kind = bcf_projected_format_kind(&bind->format_fields[field_idx]);
             group->column_count = (idx_t)format_counts[field_idx];
-            group->projected_indices = (idx_t *)duckdb_malloc(
-                (size_t)group->column_count * sizeof(idx_t));
+            group->projected_indices = duckhts_alloc_array(group->column_count, sizeof(*group->projected_indices));
             if (!group->projected_indices) {
                 snprintf(err, err_size, "%s: out of memory allocating FORMAT projection group", reader_name);
                 if (format_counts) duckdb_free(format_counts);
@@ -1485,9 +1455,10 @@ static void bcf_read_bind(duckdb_bind_info info) {
     }
 
 
-    // Create bind data
-    bcf_bind_data_t* bind = (bcf_bind_data_t*)duckdb_malloc(sizeof(bcf_bind_data_t));
-    memset(bind, 0, sizeof(bcf_bind_data_t));
+    duckdb_logical_type varchar_type = NULL, bigint_type = NULL;
+    duckdb_logical_type double_type = NULL, varchar_list_type = NULL;
+    bcf_bind_data_t* bind = duckhts_alloc_array(1, sizeof(*bind));
+    if (!bind) goto bind_oom;
     bind->file_path = file_path;
     bind->index_path = index_path;
     bind->region = region;
@@ -1499,10 +1470,7 @@ static void bcf_read_bind(duckdb_bind_info info) {
     if (!duckhts_region_list_parse(region, &bind->regions, &bind->n_regions,
                                    region_error, sizeof(region_error))) {
         duckdb_bind_set_error(info, region_error);
-        bcf_hdr_destroy(hdr);
-        hts_close(fp);
-        destroy_bind_data(bind);
-        return;
+        goto bind_error;
     }
     bind->n_samples = bcf_hdr_nsamples(hdr);
     bind->tidy_format = tidy_format;
@@ -1516,17 +1484,19 @@ static void bcf_read_bind(duckdb_bind_info info) {
 
     // Copy sample names
     if (bind->n_samples > 0) {
-        bind->sample_names = (char**)duckdb_malloc(bind->n_samples * sizeof(char*));
+        bind->sample_names = duckhts_alloc_array(bind->n_samples, sizeof(*bind->sample_names));
+        if (!bind->sample_names) goto bind_oom;
         for (int i = 0; i < bind->n_samples; i++) {
-            bind->sample_names[i] = strdup_duckdb(hdr->samples[i]);
+            bind->sample_names[i] = duckhts_copy_string(hdr->samples[i]);
+            if (!bind->sample_names[i]) goto bind_oom;
         }
     }
 
     // Create logical types for schema
-    duckdb_logical_type varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-    duckdb_logical_type bigint_type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
-    duckdb_logical_type double_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
-    duckdb_logical_type varchar_list_type = duckdb_create_list_type(varchar_type);
+    varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+    bigint_type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+    double_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
+    varchar_list_type = duckdb_create_list_type(varchar_type);
 
     int col_idx = 0;
 
@@ -1568,6 +1538,7 @@ static void bcf_read_bind(duckdb_bind_info info) {
     bind->vep_schema = vep_schema_parse(hdr, NULL, bind->additional_csq_column_types);
     if (bind->vep_schema) {
         bind->n_vep_fields = bind->vep_schema->n_fields;
+        if (bind->n_vep_fields > INT_MAX - col_idx) goto bind_too_many_columns;
         bind->vep_col_start = col_idx;
         for (int v = 0; v < bind->vep_schema->n_fields; v++) {
             const vep_field_t* field = vep_schema_get_field(bind->vep_schema, v);
@@ -1602,9 +1573,10 @@ static void bcf_read_bind(duckdb_bind_info info) {
         }
     }
 
+    if (bind->n_info_fields > INT_MAX - col_idx) goto bind_too_many_columns;
     if (bind->n_info_fields > 0) {
-        bind->info_fields = (field_meta_t*)duckdb_malloc(bind->n_info_fields * sizeof(field_meta_t));
-        memset(bind->info_fields, 0, bind->n_info_fields * sizeof(field_meta_t));
+        bind->info_fields = duckhts_alloc_array(bind->n_info_fields, sizeof(*bind->info_fields));
+        if (!bind->info_fields) goto bind_oom;
 
         int info_idx = 0;
         for (int i = 0; i < hdr->n[BCF_DT_ID] && info_idx < bind->n_info_fields; i++) {
@@ -1623,7 +1595,8 @@ static void bcf_read_bind(duckdb_bind_info info) {
                                                                  &corrected_type, &corrected_count);
 
                 field_meta_t* field = &bind->info_fields[info_idx];
-                field->name = strdup_duckdb(field_name);
+                field->name = duckhts_copy_string(field_name);
+                if (!field->name) goto bind_oom;
                 field->header_id = i;
                 field->header_type = header_type;
                 field->schema_type = header_type;  // Use header type for data
@@ -1667,12 +1640,17 @@ static void bcf_read_bind(duckdb_bind_info info) {
         if (bind->n_format_fields == 0 && header_format_count == 0) {
             bind->n_format_fields = 1;
         }
+        uint64_t format_columns = bind->tidy_format
+            ? (uint64_t)bind->n_format_fields + 1
+            : (uint64_t)bind->n_format_fields * (uint64_t)bind->n_samples;
+        if (format_columns > (uint64_t)(INT_MAX - col_idx)) goto bind_too_many_columns;
 
         if (bind->n_format_fields == 1 && header_format_count == 0) {
             // Add GT as default for old header-light fixtures.
-            bind->format_fields = (field_meta_t*)duckdb_malloc(sizeof(field_meta_t));
-            memset(bind->format_fields, 0, sizeof(field_meta_t));
-            bind->format_fields[0].name = strdup_duckdb("GT");
+            bind->format_fields = duckhts_alloc_array(1, sizeof(*bind->format_fields));
+            if (!bind->format_fields) goto bind_oom;
+            bind->format_fields[0].name = duckhts_copy_string("GT");
+            if (!bind->format_fields[0].name) goto bind_oom;
             bind->format_fields[0].header_type = BCF_HT_STR;
             bind->format_fields[0].schema_type = BCF_HT_STR;
             bind->format_fields[0].vl_type = BCF_VL_FIXED;
@@ -1680,8 +1658,8 @@ static void bcf_read_bind(duckdb_bind_info info) {
             bind->format_fields[0].is_list = 0;
         }
         if (!bind->format_fields && bind->n_format_fields > 0) {
-            bind->format_fields = (field_meta_t*)duckdb_malloc(bind->n_format_fields * sizeof(field_meta_t));
-            memset(bind->format_fields, 0, bind->n_format_fields * sizeof(field_meta_t));
+            bind->format_fields = duckhts_alloc_array(bind->n_format_fields, sizeof(*bind->format_fields));
+            if (!bind->format_fields) goto bind_oom;
 
             int fmt_idx = 0;
             for (int i = 0; i < hdr->n[BCF_DT_ID] && fmt_idx < bind->n_format_fields; i++) {
@@ -1700,7 +1678,8 @@ static void bcf_read_bind(duckdb_bind_info info) {
                                                                        &corrected_type, &corrected_count);
 
                     field_meta_t* field = &bind->format_fields[fmt_idx];
-                    field->name = strdup_duckdb(field_name);
+                    field->name = duckhts_copy_string(field_name);
+                    if (!field->name) goto bind_oom;
                     field->header_id = i;
                     field->header_type = header_type;
                     field->schema_type = header_type;
@@ -1801,24 +1780,42 @@ static void bcf_read_bind(duckdb_bind_info info) {
             bind->index_row_count_valid = bcf_try_get_index_row_count(idx ? idx : tbx->idx,
                                                                       row_multiplier,
                                                                       &bind->index_row_count);
+            if (idx) hts_idx_destroy(idx);
+            if (tbx) tbx_destroy(tbx);
 
             // Get contig names for automatic parallel contig scans.
             int n_seqs = hdr->n[BCF_DT_CTG];
             if (n_seqs > 0) {
                 bind->n_contigs = n_seqs;
-                bind->contig_names = (char**)duckdb_malloc(n_seqs * sizeof(char*));
+                bind->contig_names = duckhts_alloc_array(n_seqs, sizeof(*bind->contig_names));
+                if (!bind->contig_names) goto bind_oom;
 
                 for (int i = 0; i < n_seqs; i++) {
-                    bind->contig_names[i] = strdup_duckdb(hdr->id[BCF_DT_CTG][i].key);
+                    bind->contig_names[i] = duckhts_copy_string(hdr->id[BCF_DT_CTG][i].key);
+                    if (!bind->contig_names[i]) goto bind_oom;
                 }
             }
-
-            if (idx) hts_idx_destroy(idx);
-            if (tbx) tbx_destroy(tbx);
         }
     }
 
-    // Cleanup
+    goto bind_cleanup;
+
+bind_too_many_columns:
+    duckdb_bind_set_error(info, "read_bcf: header exceeds the supported column count");
+    goto bind_error;
+bind_oom:
+    duckdb_bind_set_error(info, "read_bcf: out of memory allocating bind schema");
+bind_error:
+    if (bind) {
+        destroy_bind_data(bind);
+        bind = NULL;
+    } else {
+        duckdb_free(file_path);
+        if (index_path) duckdb_free(index_path);
+        if (region) duckdb_free(region);
+        if (additional_csq_column_types) duckdb_free(additional_csq_column_types);
+    }
+bind_cleanup:
     duckdb_destroy_logical_type(&varchar_type);
     duckdb_destroy_logical_type(&bigint_type);
     duckdb_destroy_logical_type(&double_type);
@@ -1827,7 +1824,7 @@ static void bcf_read_bind(duckdb_bind_info info) {
     bcf_hdr_destroy(hdr);
     hts_close(fp);
 
-    duckdb_bind_set_bind_data(info, bind, destroy_bind_data);
+    if (bind) duckdb_bind_set_bind_data(info, bind, destroy_bind_data);
 }
 
 // =============================================================================
@@ -1838,8 +1835,11 @@ static void bcf_read_global_init(duckdb_init_info info) {
     bcf_bind_data_t* bind = (bcf_bind_data_t*)duckdb_init_get_bind_data(info);
     idx_t column_count = duckdb_init_get_column_count(info);
 
-    bcf_global_init_data_t* global = (bcf_global_init_data_t*)duckdb_malloc(sizeof(bcf_global_init_data_t));
-    memset(global, 0, sizeof(bcf_global_init_data_t));
+    bcf_global_init_data_t* global = duckhts_alloc_array(1, sizeof(*global));
+    if (!global) {
+        duckdb_init_set_error(info, "read_bcf: out of memory allocating global state");
+        return;
+    }
 
     global->current_contig = 0;
     global->has_region = (bind->n_regions > 0);
@@ -1878,12 +1878,20 @@ static void bcf_read_local_init(duckdb_init_info info) {
     bcf_bind_data_t* bind = (bcf_bind_data_t*)duckdb_init_get_bind_data(info);
     const char *reader_name = "read_bcf";
 
-    bcf_init_data_t* local = (bcf_init_data_t*)duckdb_malloc(sizeof(bcf_init_data_t));
-    memset(local, 0, sizeof(bcf_init_data_t));
+    bcf_init_data_t* local = duckhts_alloc_array(1, sizeof(*local));
+    if (!local) {
+        duckdb_init_set_error(info, "read_bcf: out of memory allocating worker state");
+        return;
+    }
 
     local->column_count = duckdb_init_get_column_count(info);
     if (local->column_count > 0) {
-        local->column_ids = (idx_t*)duckdb_malloc(sizeof(idx_t) * local->column_count);
+        local->column_ids = duckhts_alloc_array(local->column_count, sizeof(*local->column_ids));
+        if (!local->column_ids) {
+            duckdb_init_set_error(info, "read_bcf: out of memory allocating projected columns");
+            destroy_init_data(local);
+            return;
+        }
         for (idx_t i = 0; i < local->column_count; i++) {
             local->column_ids[i] = duckdb_init_get_column_index(info, i);
         }
@@ -2500,7 +2508,9 @@ static void bcf_read_function(duckdb_function_info info, duckdb_data_chunk outpu
     // Cache vector pointers to reduce repeated calls
     duckdb_vector* vectors = NULL;
     if (init->column_count > 0) {
-        vectors = (duckdb_vector*)duckdb_malloc(init->column_count * sizeof(duckdb_vector));
+        if (init->column_count <= SIZE_MAX / sizeof(*vectors)) {
+            vectors = duckdb_malloc((size_t)init->column_count * sizeof(*vectors));
+        }
         if (!vectors) {
             duckdb_function_set_error(info, "read_bcf: out of memory allocating output vector pointers");
             duckdb_data_chunk_set_size(output, 0);

--- a/r/Rduckhts/inst/duckhts_extension/include/duckdb_alloc.h
+++ b/r/Rduckhts/inst/duckhts_extension/include/duckdb_alloc.h
@@ -1,0 +1,27 @@
+#ifndef DUCKHTS_DUCKDB_ALLOC_H
+#define DUCKHTS_DUCKDB_ALLOC_H
+
+#include <stdint.h>
+#include <string.h>
+
+/* Include after duckdb_extension.h and DUCKDB_EXTENSION_EXTERN. Storage is
+ * owned by the caller and released with duckdb_free. Empty arrays return NULL.
+ * Zero each allocation immediately so partial owners are safe to destroy. */
+static inline void *duckhts_alloc_array(idx_t count, size_t width) {
+    if (!count || !width || count > SIZE_MAX / width) return NULL;
+    size_t bytes = (size_t)count * width;
+    void *data = duckdb_malloc(bytes);
+    if (data) memset(data, 0, bytes);
+    return data;
+}
+
+static inline char *duckhts_copy_string(const char *text) {
+    if (!text) return NULL;
+    size_t length = strlen(text);
+    if (length == SIZE_MAX) return NULL;
+    char *copy = duckdb_malloc(length + 1);
+    if (copy) memcpy(copy, text, length + 1);
+    return copy;
+}
+
+#endif

--- a/r/Rduckhts/inst/duckhts_extension/seq_reader.c
+++ b/r/Rduckhts/inst/duckhts_extension/seq_reader.c
@@ -45,6 +45,7 @@ DUCKDB_EXTENSION_EXTERN
 #include <htslib/kstring.h>
 
 #include "include/hts_io_tuning.h"
+#include "include/duckdb_alloc.h"
 #include "include/region_list.h"
 #include "include/seq_encoding.h"
 #include "include/quality_encoding.h"
@@ -448,8 +449,12 @@ static void seq_read_bind(duckdb_bind_info info, int is_fastq) {
     }
     sam_close(fp);
 
-    seq_bind_data_t *bind = (seq_bind_data_t *)duckdb_malloc(sizeof(seq_bind_data_t));
-    memset(bind, 0, sizeof(seq_bind_data_t));
+    seq_bind_data_t *bind = duckhts_alloc_array(1, sizeof(*bind));
+    if (!bind) {
+        duckdb_bind_set_error(info, "FASTA/FASTQ: out of memory allocating bind state");
+        duckdb_free(file_path);
+        return;
+    }
     bind->file_path = file_path;
     bind->is_fastq = is_fastq;
     bind->direct_fastq = is_fastq && fmt == fastq_format;
@@ -656,13 +661,21 @@ static void fastq_read_bind(duckdb_bind_info info) { seq_read_bind(info, 1); }
 static void seq_read_init(duckdb_init_info info) {
     seq_bind_data_t *bind = (seq_bind_data_t *)duckdb_init_get_bind_data(info);
 
-    seq_init_data_t *init = (seq_init_data_t *)duckdb_malloc(sizeof(seq_init_data_t));
-    memset(init, 0, sizeof(seq_init_data_t));
+    seq_init_data_t *init = duckhts_alloc_array(1, sizeof(*init));
+    if (!init) {
+        duckdb_init_set_error(info, "FASTA/FASTQ: out of memory allocating worker state");
+        return;
+    }
 
     /* Projection pushdown: record which columns DuckDB actually needs */
     init->column_count = duckdb_init_get_column_count(info);
     if (init->column_count > 0) {
-        init->column_ids = (idx_t *)duckdb_malloc(sizeof(idx_t) * init->column_count);
+        init->column_ids = duckhts_alloc_array(init->column_count, sizeof(*init->column_ids));
+        if (!init->column_ids) {
+            duckdb_init_set_error(info, "FASTA/FASTQ: out of memory allocating projected columns");
+            destroy_seq_init(init);
+            return;
+        }
         for (idx_t i = 0; i < init->column_count; i++)
             init->column_ids[i] = duckdb_init_get_column_index(info, i);
     }
@@ -785,6 +798,11 @@ static void seq_read_init(duckdb_init_info info) {
     }
 
     init->rec = bam_init1();
+    if (!init->rec) {
+        duckdb_init_set_error(info, "FASTA/FASTQ: out of memory allocating sequence record");
+        destroy_seq_init(init);
+        return;
+    }
 
     if (bind->paired) {
         init->fp_mate = sam_open(bind->mate_path, "r");
@@ -802,6 +820,11 @@ static void seq_read_init(duckdb_init_info info) {
             return;
         }
         init->rec_mate = bam_init1();
+        if (!init->rec_mate) {
+            duckdb_init_set_error(info, "read_fastq: out of memory allocating mate record");
+            destroy_seq_init(init);
+            return;
+        }
     }
 
     if (!bind->is_fastq && bind->n_regions > 0) {

--- a/r/Rduckhts/inst/extdata/bam_read_groups.sam
+++ b/r/Rduckhts/inst/extdata/bam_read_groups.sam
@@ -1,0 +1,14 @@
+@HD	VN:1.6	SO:unknown
+@SQ	SN:chr1	LN:100
+@RG	ID:one	SM:sample_one
+@RG	ID:missing
+@RG	ID:three	SM:sample_three
+@CO	DuckHTS synthetic fixture: repeated, missing, unknown, and changing read groups.
+r1	0	chr1	1	60	1M	*	0	0	A	I	RG:Z:one
+r2	0	chr1	2	60	1M	*	0	0	C	I	RG:Z:one
+r3	0	chr1	3	60	1M	*	0	0	G	I	RG:Z:missing
+r4	0	chr1	4	60	1M	*	0	0	T	I	RG:Z:missing
+r5	0	chr1	5	60	1M	*	0	0	A	I	RG:Z:three
+r6	0	chr1	6	60	1M	*	0	0	C	I
+r7	0	chr1	7	60	1M	*	0	0	G	I	RG:Z:unknown
+r8	0	chr1	8	60	1M	*	0	0	T	I	RG:Z:one

--- a/r/Rduckhts/inst/tinytest/test_bam_scan.R
+++ b/r/Rduckhts/inst/tinytest/test_bam_scan.R
@@ -4,6 +4,15 @@ library(DBI)
 test_bam_full_scan <- function() {
   con <- rduckhts_connect()
   on.exit(dbDisconnect(con, shutdown = TRUE))
+  read_groups <- system.file("extdata", "bam_read_groups.sam", package = "Rduckhts")
+  expect_true(nzchar(read_groups))
+  groups <- dbGetQuery(con, sprintf(paste(
+    "SELECT QNAME, READ_GROUP_ID, SAMPLE_ID FROM read_bam(%s,",
+    "scan_mode := 'sequential', decompression_threads := 0) ORDER BY QNAME"),
+    dbQuoteString(con, read_groups)))
+  expect_equal(groups$QNAME, paste0("r", 1:8))
+  expect_equal(groups$READ_GROUP_ID, c("one", "one", "missing", "missing", "three", NA, "unknown", "one"))
+  expect_equal(groups$SAMPLE_ID, c("sample_one", "sample_one", NA, NA, "sample_three", NA, NA, "sample_one"))
   expected_counts <- c(mixed = 5L, single = 3L, all_unplaced = 2053L, empty = 0L)
   for (threads in c(1L, 4L)) {
     dbExecute(con, sprintf("SET threads=%d", threads))

--- a/scripts/test_sanitized_extension.sh
+++ b/scripts/test_sanitized_extension.sh
@@ -129,4 +129,14 @@ if [ "$sanitizer" = asan ]; then
 else
   "${runtime[@]}" "$build_dir/duckhts_region_list_test"
 fi
+cmake --build "$build_dir" --target duckhts_reader_alloc_probe -j2
+python_runtime=("${runtime[@]}")
+if [ "$sanitizer" = asan ]; then
+  # Python does not link C++; load it at startup so ASan can resolve
+  # __cxa_throw before DuckDB is imported and exercises query errors.
+  python_runtime=(env "ASAN_OPTIONS=detect_leaks=0:halt_on_error=1"
+    "LD_PRELOAD=$(${CC:-cc} -print-file-name=libasan.so):$(${CXX:-c++} -print-file-name=libstdc++.so)")
+fi
+"${python_runtime[@]}" ./configure/venv/bin/python3 test/scripts/reader_alloc_test.py \
+  --extension "$extension" --probe "$build_dir/libduckhts_reader_alloc_probe.so"
 echo "$sanitizer complete-extension gates: OK"

--- a/src/bam_reader.c
+++ b/src/bam_reader.c
@@ -36,6 +36,7 @@ DUCKDB_EXTENSION_EXTERN
 #include <htslib/kstring.h>
 
 #include "include/hts_io_tuning.h"
+#include "include/duckdb_alloc.h"
 #include "include/region_list.h"
 #include "include/seq_encoding.h"
 #include "include/quality_encoding.h"
@@ -290,7 +291,7 @@ typedef struct {
 
     /* Read group caching */
     char *last_rg_id;
-    char *last_sample_id;
+    int has_sample;
     kstring_t rg_tmp;
 } bam_local_init_data_t;
 
@@ -324,8 +325,7 @@ static void destroy_bam_local(void *data) {
     if (l->column_ids) duckdb_free(l->column_ids);
     if (l->seq_buf) free(l->seq_buf);
     if (l->qual_buf) free(l->qual_buf);
-    if (l->last_rg_id) free(l->last_rg_id);
-    if (l->last_sample_id) free(l->last_sample_id);
+    if (l->last_rg_id) duckdb_free(l->last_rg_id);
     ks_free(&l->rg_tmp);
     ks_free(&l->cigar_tmp);
     ks_free(&l->aux_tmp);
@@ -345,7 +345,8 @@ static int bam_region_name2id(void *hdr, const char *name) {
  * ================================================================ */
 
 static int ensure_seq_buf(bam_local_init_data_t *l, int seq_len) {
-    size_t need = (size_t)(seq_len + 1);
+    if (seq_len < 0 || (uint64_t)seq_len >= SIZE_MAX / 2) return 0;
+    size_t need = (size_t)seq_len + 1;
     if (need > l->seq_buf_cap) {
         size_t new_cap = need * 2;
         char *new_seq = (char *)realloc(l->seq_buf, new_cap);
@@ -525,8 +526,17 @@ static void bam_read_bind(duckdb_bind_info info) {
         return;
     }
 
-    bam_bind_data_t *bind = (bam_bind_data_t *)duckdb_malloc(sizeof(bam_bind_data_t));
-    memset(bind, 0, sizeof(bam_bind_data_t));
+    bam_bind_data_t *bind = duckhts_alloc_array(1, sizeof(*bind));
+    if (!bind) {
+        duckdb_bind_set_error(info, "read_bam: out of memory allocating bind state");
+        sam_hdr_destroy(hdr);
+        sam_close(fp);
+        duckdb_free(file_path);
+        if (index_path) duckdb_free(index_path);
+        if (region) duckdb_free(region);
+        if (reference) duckdb_free(reference);
+        return;
+    }
     bind->file_path = file_path;
     bind->index_path = index_path;
     bind->reference = reference;
@@ -722,9 +732,11 @@ static void bam_read_global_init(duckdb_init_info info) {
     bam_bind_data_t *bind = (bam_bind_data_t *)duckdb_init_get_bind_data(info);
     idx_t column_count = duckdb_init_get_column_count(info);
 
-    bam_global_init_data_t *global = (bam_global_init_data_t *)duckdb_malloc(
-        sizeof(bam_global_init_data_t));
-    memset(global, 0, sizeof(bam_global_init_data_t));
+    bam_global_init_data_t *global = duckhts_alloc_array(1, sizeof(*global));
+    if (!global) {
+        duckdb_init_set_error(info, "read_bam: out of memory allocating global state");
+        return;
+    }
 
     global->current_partition = 0;
     global->has_region = (bind->n_regions > 0);
@@ -756,13 +768,20 @@ static void bam_read_global_init(duckdb_init_info info) {
 static void bam_read_local_init(duckdb_init_info info) {
     bam_bind_data_t *bind = (bam_bind_data_t *)duckdb_init_get_bind_data(info);
 
-    bam_local_init_data_t *local = (bam_local_init_data_t *)duckdb_malloc(
-        sizeof(bam_local_init_data_t));
-    memset(local, 0, sizeof(bam_local_init_data_t));
+    bam_local_init_data_t *local = duckhts_alloc_array(1, sizeof(*local));
+    if (!local) {
+        duckdb_init_set_error(info, "read_bam: out of memory allocating worker state");
+        return;
+    }
 
     local->column_count = duckdb_init_get_column_count(info);
     if (local->column_count > 0) {
-        local->column_ids = (idx_t *)duckdb_malloc(sizeof(idx_t) * local->column_count);
+        local->column_ids = duckhts_alloc_array(local->column_count, sizeof(*local->column_ids));
+        if (!local->column_ids) {
+            duckdb_init_set_error(info, "read_bam: out of memory allocating projected columns");
+            destroy_bam_local(local);
+            return;
+        }
         for (idx_t i = 0; i < local->column_count; i++) {
             local->column_ids[i] = duckdb_init_get_column_index(info, i);
             if (local->column_ids[i] == BAM_COL_SEQ || local->column_ids[i] == BAM_COL_QUAL) {
@@ -790,7 +809,7 @@ static void bam_read_local_init(duckdb_init_info info) {
     local->fp = sam_open(bind->file_path, "r");
     if (!local->fp) {
         duckdb_init_set_error(info, "Failed to open SAM/BAM/CRAM file");
-        duckdb_free(local);
+        destroy_bam_local(local);
         return;
     }
     duckhts_apply_remote_hts_tuning(
@@ -804,8 +823,7 @@ static void bam_read_local_init(duckdb_init_info info) {
     if (bind->reference) {
         if (hts_set_opt(local->fp, CRAM_OPT_REFERENCE, bind->reference) < 0) {
             duckdb_init_set_error(info, "Failed to set CRAM reference");
-            sam_close(local->fp);
-            duckdb_free(local);
+            destroy_bam_local(local);
             return;
         }
     }
@@ -822,17 +840,18 @@ static void bam_read_local_init(duckdb_init_info info) {
     /* Read header — each thread needs its own copy */
     local->hdr = sam_hdr_read(local->fp);
     if (!local->hdr) {
-        sam_close(local->fp); local->fp = NULL;
         duckdb_init_set_error(info, "Failed to read SAM/BAM/CRAM header");
-        duckdb_free(local);
+        destroy_bam_local(local);
         return;
     }
 
     /* Allocate a reusable bam1_t record */
     local->rec = bam_init1();
-    local->rg_tmp.l = 0;
-    local->rg_tmp.m = 0;
-    local->rg_tmp.s = NULL;
+    if (!local->rec) {
+        duckdb_init_set_error(info, "read_bam: out of memory allocating alignment record");
+        destroy_bam_local(local);
+        return;
+    }
 
     /* Load index if needed for parallel scanning or region queries */
     if (is_parallel || bind->n_regions > 0) {
@@ -1192,18 +1211,29 @@ static void bam_read_function(duckdb_function_info info, duckdb_data_chunk outpu
                     break;
                 }
                 if (!local->last_rg_id || strcmp(local->last_rg_id, rg) != 0) {
-                    free(local->last_rg_id);
-                    free(local->last_sample_id);
-                    local->last_rg_id = strdup(rg);
-                    local->last_sample_id = NULL;
-                    local->rg_tmp.l = 0;
-                    if (sam_hdr_find_tag_id(local->hdr, "RG", "ID", rg, "SM", &local->rg_tmp) == 0 &&
-                        local->rg_tmp.s && local->rg_tmp.l > 0) {
-                        local->last_sample_id = strdup(local->rg_tmp.s);
+                    char *next_rg = duckhts_copy_string(rg);
+                    if (!next_rg) {
+                        duckdb_function_set_error(info, "read_bam: out of memory caching SAMPLE_ID read group");
+                        local->done = 1;
+                        duckdb_data_chunk_set_size(output, 0);
+                        return;
                     }
+                    local->rg_tmp.l = 0;
+                    int status = sam_hdr_find_tag_id(local->hdr, "RG", "ID", rg, "SM", &local->rg_tmp);
+                    if (status < -1) {
+                        duckdb_free(next_rg);
+                        duckdb_function_set_error(info, "read_bam: HTSlib failed to resolve SAMPLE_ID");
+                        local->done = 1;
+                        duckdb_data_chunk_set_size(output, 0);
+                        return;
+                    }
+                    if (local->last_rg_id) duckdb_free(local->last_rg_id);
+                    local->last_rg_id = next_rg;
+                    local->has_sample = status == 0 && local->rg_tmp.l > 0;
                 }
-                if (local->last_sample_id) {
-                    duckdb_vector_assign_string_element(vec, row_count, local->last_sample_id);
+                if (local->has_sample) {
+                    /* DuckDB copies the worker-owned lookup string. */
+                    duckdb_vector_assign_string_element_len(vec, row_count, local->rg_tmp.s, local->rg_tmp.l);
                 } else {
                     set_null(vec, row_count);
                 }

--- a/src/bcf_reader.c
+++ b/src/bcf_reader.c
@@ -50,6 +50,7 @@ DUCKDB_EXTENSION_EXTERN
 #include <htslib/kstring.h>
 
 #include "include/hts_io_tuning.h"
+#include "include/duckdb_alloc.h"
 #include "include/region_list.h"
 
 // =============================================================================
@@ -428,48 +429,33 @@ static int bcf_decode_cache_init(bcf_init_data_t *init, const bcf_bind_data_t *b
 
     if (bind->n_format_fields > 0) {
         size_t nfmt = (size_t)bind->n_format_fields;
-        init->fmt_loaded = (int *)duckdb_malloc(nfmt * sizeof(int));
-        init->fmt_ret = (int *)duckdb_malloc(nfmt * sizeof(int));
-        init->fmt_n_values = (int *)duckdb_malloc(nfmt * sizeof(int));
-        init->fmt_i32 = (int32_t **)duckdb_malloc(nfmt * sizeof(int32_t *));
-        init->fmt_f32 = (float **)duckdb_malloc(nfmt * sizeof(float *));
-        init->fmt_str = (char ***)duckdb_malloc(nfmt * sizeof(char **));
-        /* Cleanup must see only initialized element pointers after any
-         * allocation failure, including a partially constructed cache. */
-        if (init->fmt_i32) memset(init->fmt_i32, 0, nfmt * sizeof(int32_t *));
-        if (init->fmt_f32) memset(init->fmt_f32, 0, nfmt * sizeof(float *));
-        if (init->fmt_str) memset(init->fmt_str, 0, nfmt * sizeof(char **));
+        init->fmt_loaded = duckhts_alloc_array(nfmt, sizeof(*init->fmt_loaded));
+        init->fmt_ret = duckhts_alloc_array(nfmt, sizeof(*init->fmt_ret));
+        init->fmt_n_values = duckhts_alloc_array(nfmt, sizeof(*init->fmt_n_values));
+        init->fmt_i32 = duckhts_alloc_array(nfmt, sizeof(*init->fmt_i32));
+        init->fmt_f32 = duckhts_alloc_array(nfmt, sizeof(*init->fmt_f32));
+        init->fmt_str = duckhts_alloc_array(nfmt, sizeof(*init->fmt_str));
         if (!init->fmt_loaded || !init->fmt_ret || !init->fmt_n_values ||
             !init->fmt_i32 || !init->fmt_f32 || !init->fmt_str) {
             bcf_decode_cache_free(init);
             return 0;
         }
-        memset(init->fmt_loaded, 0, nfmt * sizeof(int));
-        memset(init->fmt_ret, 0, nfmt * sizeof(int));
-        memset(init->fmt_n_values, 0, nfmt * sizeof(int));
     }
 
     if (bind->n_info_fields > 0) {
         size_t ninfo = (size_t)bind->n_info_fields;
-        init->info_loaded = (int *)duckdb_malloc(ninfo * sizeof(int));
-        init->info_ret = (int *)duckdb_malloc(ninfo * sizeof(int));
-        init->info_n_values = (int *)duckdb_malloc(ninfo * sizeof(int));
-        init->info_flag = (int *)duckdb_malloc(ninfo * sizeof(int));
-        init->info_i32 = (int32_t **)duckdb_malloc(ninfo * sizeof(int32_t *));
-        init->info_f32 = (float **)duckdb_malloc(ninfo * sizeof(float *));
-        init->info_str = (char **)duckdb_malloc(ninfo * sizeof(char *));
-        if (init->info_i32) memset(init->info_i32, 0, ninfo * sizeof(int32_t *));
-        if (init->info_f32) memset(init->info_f32, 0, ninfo * sizeof(float *));
-        if (init->info_str) memset(init->info_str, 0, ninfo * sizeof(char *));
+        init->info_loaded = duckhts_alloc_array(ninfo, sizeof(*init->info_loaded));
+        init->info_ret = duckhts_alloc_array(ninfo, sizeof(*init->info_ret));
+        init->info_n_values = duckhts_alloc_array(ninfo, sizeof(*init->info_n_values));
+        init->info_flag = duckhts_alloc_array(ninfo, sizeof(*init->info_flag));
+        init->info_i32 = duckhts_alloc_array(ninfo, sizeof(*init->info_i32));
+        init->info_f32 = duckhts_alloc_array(ninfo, sizeof(*init->info_f32));
+        init->info_str = duckhts_alloc_array(ninfo, sizeof(*init->info_str));
         if (!init->info_loaded || !init->info_ret || !init->info_n_values ||
             !init->info_flag || !init->info_i32 || !init->info_f32 || !init->info_str) {
             bcf_decode_cache_free(init);
             return 0;
         }
-        memset(init->info_loaded, 0, ninfo * sizeof(int));
-        memset(init->info_ret, 0, ninfo * sizeof(int));
-        memset(init->info_n_values, 0, ninfo * sizeof(int));
-        memset(init->info_flag, 0, ninfo * sizeof(int));
     }
 
     return 1;
@@ -506,14 +492,6 @@ static void destroy_init_data(void* data) {
 // =============================================================================
 // String Utilities
 // =============================================================================
-
-static char* strdup_duckdb(const char* s) {
-    if (!s) return NULL;
-    size_t len = strlen(s) + 1;
-    char* copy = (char*)duckdb_malloc(len);
-    if (copy) memcpy(copy, s, len);
-    return copy;
-}
 
 static int bcf_region_name2id(void *hdr, const char *name) {
     return bcf_hdr_name2id((bcf_hdr_t *)hdr, name);
@@ -873,13 +851,11 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
 
     const char *reader_name = "read_bcf";
 
-    local->projected_cols = (bcf_projected_col_t *)duckdb_malloc(
-        (size_t)local->column_count * sizeof(bcf_projected_col_t));
+    local->projected_cols = duckhts_alloc_array(local->column_count, sizeof(*local->projected_cols));
     if (!local->projected_cols) {
         snprintf(err, err_size, "%s: out of memory allocating projected column descriptors", reader_name);
         return 0;
     }
-    memset(local->projected_cols, 0, (size_t)local->column_count * sizeof(bcf_projected_col_t));
 
     int tidy_mode = bind->tidy_format && bind->n_samples > 0;
 
@@ -987,12 +963,11 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
 
     int *format_counts = NULL;
     if (bind->n_format_fields > 0) {
-        format_counts = (int *)duckdb_malloc((size_t)bind->n_format_fields * sizeof(int));
+        format_counts = duckhts_alloc_array(bind->n_format_fields, sizeof(*format_counts));
         if (!format_counts) {
             snprintf(err, err_size, "%s: out of memory allocating FORMAT projection counts", reader_name);
             return 0;
         }
-        memset(format_counts, 0, (size_t)bind->n_format_fields * sizeof(int));
     }
 
     for (idx_t i = 0; i < local->column_count; i++) {
@@ -1010,8 +985,7 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
     }
 
     if (local->site_column_count > 0) {
-        local->site_column_indices = (idx_t *)duckdb_malloc(
-            (size_t)local->site_column_count * sizeof(idx_t));
+        local->site_column_indices = duckhts_alloc_array(local->site_column_count, sizeof(*local->site_column_indices));
         if (!local->site_column_indices) {
             snprintf(err, err_size, "%s: out of memory allocating site column descriptors", reader_name);
             if (format_counts) duckdb_free(format_counts);
@@ -1022,10 +996,9 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
     int *format_group_for_field = NULL;
     int *format_group_offsets = NULL;
     if (local->n_format_groups > 0) {
-        local->format_groups = (bcf_format_group_t *)duckdb_malloc(
-            (size_t)local->n_format_groups * sizeof(bcf_format_group_t));
-        format_group_for_field = (int *)duckdb_malloc((size_t)bind->n_format_fields * sizeof(int));
-        format_group_offsets = (int *)duckdb_malloc((size_t)local->n_format_groups * sizeof(int));
+        local->format_groups = duckhts_alloc_array(local->n_format_groups, sizeof(*local->format_groups));
+        format_group_for_field = duckhts_alloc_array(bind->n_format_fields, sizeof(*format_group_for_field));
+        format_group_offsets = duckhts_alloc_array(local->n_format_groups, sizeof(*format_group_offsets));
         if (!local->format_groups || !format_group_for_field || !format_group_offsets) {
             snprintf(err, err_size, "%s: out of memory allocating FORMAT projection groups", reader_name);
             if (format_counts) duckdb_free(format_counts);
@@ -1033,11 +1006,9 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
             if (format_group_offsets) duckdb_free(format_group_offsets);
             return 0;
         }
-        memset(local->format_groups, 0, (size_t)local->n_format_groups * sizeof(bcf_format_group_t));
         for (int i = 0; i < bind->n_format_fields; i++) {
             format_group_for_field[i] = -1;
         }
-        memset(format_group_offsets, 0, (size_t)local->n_format_groups * sizeof(int));
 
         int group_idx = 0;
         for (int field_idx = 0; field_idx < bind->n_format_fields; field_idx++) {
@@ -1048,8 +1019,7 @@ static int bcf_projected_columns_init(bcf_init_data_t *local, const bcf_bind_dat
             group->field_idx = field_idx;
             group->kind = bcf_projected_format_kind(&bind->format_fields[field_idx]);
             group->column_count = (idx_t)format_counts[field_idx];
-            group->projected_indices = (idx_t *)duckdb_malloc(
-                (size_t)group->column_count * sizeof(idx_t));
+            group->projected_indices = duckhts_alloc_array(group->column_count, sizeof(*group->projected_indices));
             if (!group->projected_indices) {
                 snprintf(err, err_size, "%s: out of memory allocating FORMAT projection group", reader_name);
                 if (format_counts) duckdb_free(format_counts);
@@ -1485,9 +1455,10 @@ static void bcf_read_bind(duckdb_bind_info info) {
     }
 
 
-    // Create bind data
-    bcf_bind_data_t* bind = (bcf_bind_data_t*)duckdb_malloc(sizeof(bcf_bind_data_t));
-    memset(bind, 0, sizeof(bcf_bind_data_t));
+    duckdb_logical_type varchar_type = NULL, bigint_type = NULL;
+    duckdb_logical_type double_type = NULL, varchar_list_type = NULL;
+    bcf_bind_data_t* bind = duckhts_alloc_array(1, sizeof(*bind));
+    if (!bind) goto bind_oom;
     bind->file_path = file_path;
     bind->index_path = index_path;
     bind->region = region;
@@ -1499,10 +1470,7 @@ static void bcf_read_bind(duckdb_bind_info info) {
     if (!duckhts_region_list_parse(region, &bind->regions, &bind->n_regions,
                                    region_error, sizeof(region_error))) {
         duckdb_bind_set_error(info, region_error);
-        bcf_hdr_destroy(hdr);
-        hts_close(fp);
-        destroy_bind_data(bind);
-        return;
+        goto bind_error;
     }
     bind->n_samples = bcf_hdr_nsamples(hdr);
     bind->tidy_format = tidy_format;
@@ -1516,17 +1484,19 @@ static void bcf_read_bind(duckdb_bind_info info) {
 
     // Copy sample names
     if (bind->n_samples > 0) {
-        bind->sample_names = (char**)duckdb_malloc(bind->n_samples * sizeof(char*));
+        bind->sample_names = duckhts_alloc_array(bind->n_samples, sizeof(*bind->sample_names));
+        if (!bind->sample_names) goto bind_oom;
         for (int i = 0; i < bind->n_samples; i++) {
-            bind->sample_names[i] = strdup_duckdb(hdr->samples[i]);
+            bind->sample_names[i] = duckhts_copy_string(hdr->samples[i]);
+            if (!bind->sample_names[i]) goto bind_oom;
         }
     }
 
     // Create logical types for schema
-    duckdb_logical_type varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-    duckdb_logical_type bigint_type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
-    duckdb_logical_type double_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
-    duckdb_logical_type varchar_list_type = duckdb_create_list_type(varchar_type);
+    varchar_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+    bigint_type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+    double_type = duckdb_create_logical_type(DUCKDB_TYPE_DOUBLE);
+    varchar_list_type = duckdb_create_list_type(varchar_type);
 
     int col_idx = 0;
 
@@ -1568,6 +1538,7 @@ static void bcf_read_bind(duckdb_bind_info info) {
     bind->vep_schema = vep_schema_parse(hdr, NULL, bind->additional_csq_column_types);
     if (bind->vep_schema) {
         bind->n_vep_fields = bind->vep_schema->n_fields;
+        if (bind->n_vep_fields > INT_MAX - col_idx) goto bind_too_many_columns;
         bind->vep_col_start = col_idx;
         for (int v = 0; v < bind->vep_schema->n_fields; v++) {
             const vep_field_t* field = vep_schema_get_field(bind->vep_schema, v);
@@ -1602,9 +1573,10 @@ static void bcf_read_bind(duckdb_bind_info info) {
         }
     }
 
+    if (bind->n_info_fields > INT_MAX - col_idx) goto bind_too_many_columns;
     if (bind->n_info_fields > 0) {
-        bind->info_fields = (field_meta_t*)duckdb_malloc(bind->n_info_fields * sizeof(field_meta_t));
-        memset(bind->info_fields, 0, bind->n_info_fields * sizeof(field_meta_t));
+        bind->info_fields = duckhts_alloc_array(bind->n_info_fields, sizeof(*bind->info_fields));
+        if (!bind->info_fields) goto bind_oom;
 
         int info_idx = 0;
         for (int i = 0; i < hdr->n[BCF_DT_ID] && info_idx < bind->n_info_fields; i++) {
@@ -1623,7 +1595,8 @@ static void bcf_read_bind(duckdb_bind_info info) {
                                                                  &corrected_type, &corrected_count);
 
                 field_meta_t* field = &bind->info_fields[info_idx];
-                field->name = strdup_duckdb(field_name);
+                field->name = duckhts_copy_string(field_name);
+                if (!field->name) goto bind_oom;
                 field->header_id = i;
                 field->header_type = header_type;
                 field->schema_type = header_type;  // Use header type for data
@@ -1667,12 +1640,17 @@ static void bcf_read_bind(duckdb_bind_info info) {
         if (bind->n_format_fields == 0 && header_format_count == 0) {
             bind->n_format_fields = 1;
         }
+        uint64_t format_columns = bind->tidy_format
+            ? (uint64_t)bind->n_format_fields + 1
+            : (uint64_t)bind->n_format_fields * (uint64_t)bind->n_samples;
+        if (format_columns > (uint64_t)(INT_MAX - col_idx)) goto bind_too_many_columns;
 
         if (bind->n_format_fields == 1 && header_format_count == 0) {
             // Add GT as default for old header-light fixtures.
-            bind->format_fields = (field_meta_t*)duckdb_malloc(sizeof(field_meta_t));
-            memset(bind->format_fields, 0, sizeof(field_meta_t));
-            bind->format_fields[0].name = strdup_duckdb("GT");
+            bind->format_fields = duckhts_alloc_array(1, sizeof(*bind->format_fields));
+            if (!bind->format_fields) goto bind_oom;
+            bind->format_fields[0].name = duckhts_copy_string("GT");
+            if (!bind->format_fields[0].name) goto bind_oom;
             bind->format_fields[0].header_type = BCF_HT_STR;
             bind->format_fields[0].schema_type = BCF_HT_STR;
             bind->format_fields[0].vl_type = BCF_VL_FIXED;
@@ -1680,8 +1658,8 @@ static void bcf_read_bind(duckdb_bind_info info) {
             bind->format_fields[0].is_list = 0;
         }
         if (!bind->format_fields && bind->n_format_fields > 0) {
-            bind->format_fields = (field_meta_t*)duckdb_malloc(bind->n_format_fields * sizeof(field_meta_t));
-            memset(bind->format_fields, 0, bind->n_format_fields * sizeof(field_meta_t));
+            bind->format_fields = duckhts_alloc_array(bind->n_format_fields, sizeof(*bind->format_fields));
+            if (!bind->format_fields) goto bind_oom;
 
             int fmt_idx = 0;
             for (int i = 0; i < hdr->n[BCF_DT_ID] && fmt_idx < bind->n_format_fields; i++) {
@@ -1700,7 +1678,8 @@ static void bcf_read_bind(duckdb_bind_info info) {
                                                                        &corrected_type, &corrected_count);
 
                     field_meta_t* field = &bind->format_fields[fmt_idx];
-                    field->name = strdup_duckdb(field_name);
+                    field->name = duckhts_copy_string(field_name);
+                    if (!field->name) goto bind_oom;
                     field->header_id = i;
                     field->header_type = header_type;
                     field->schema_type = header_type;
@@ -1801,24 +1780,42 @@ static void bcf_read_bind(duckdb_bind_info info) {
             bind->index_row_count_valid = bcf_try_get_index_row_count(idx ? idx : tbx->idx,
                                                                       row_multiplier,
                                                                       &bind->index_row_count);
+            if (idx) hts_idx_destroy(idx);
+            if (tbx) tbx_destroy(tbx);
 
             // Get contig names for automatic parallel contig scans.
             int n_seqs = hdr->n[BCF_DT_CTG];
             if (n_seqs > 0) {
                 bind->n_contigs = n_seqs;
-                bind->contig_names = (char**)duckdb_malloc(n_seqs * sizeof(char*));
+                bind->contig_names = duckhts_alloc_array(n_seqs, sizeof(*bind->contig_names));
+                if (!bind->contig_names) goto bind_oom;
 
                 for (int i = 0; i < n_seqs; i++) {
-                    bind->contig_names[i] = strdup_duckdb(hdr->id[BCF_DT_CTG][i].key);
+                    bind->contig_names[i] = duckhts_copy_string(hdr->id[BCF_DT_CTG][i].key);
+                    if (!bind->contig_names[i]) goto bind_oom;
                 }
             }
-
-            if (idx) hts_idx_destroy(idx);
-            if (tbx) tbx_destroy(tbx);
         }
     }
 
-    // Cleanup
+    goto bind_cleanup;
+
+bind_too_many_columns:
+    duckdb_bind_set_error(info, "read_bcf: header exceeds the supported column count");
+    goto bind_error;
+bind_oom:
+    duckdb_bind_set_error(info, "read_bcf: out of memory allocating bind schema");
+bind_error:
+    if (bind) {
+        destroy_bind_data(bind);
+        bind = NULL;
+    } else {
+        duckdb_free(file_path);
+        if (index_path) duckdb_free(index_path);
+        if (region) duckdb_free(region);
+        if (additional_csq_column_types) duckdb_free(additional_csq_column_types);
+    }
+bind_cleanup:
     duckdb_destroy_logical_type(&varchar_type);
     duckdb_destroy_logical_type(&bigint_type);
     duckdb_destroy_logical_type(&double_type);
@@ -1827,7 +1824,7 @@ static void bcf_read_bind(duckdb_bind_info info) {
     bcf_hdr_destroy(hdr);
     hts_close(fp);
 
-    duckdb_bind_set_bind_data(info, bind, destroy_bind_data);
+    if (bind) duckdb_bind_set_bind_data(info, bind, destroy_bind_data);
 }
 
 // =============================================================================
@@ -1838,8 +1835,11 @@ static void bcf_read_global_init(duckdb_init_info info) {
     bcf_bind_data_t* bind = (bcf_bind_data_t*)duckdb_init_get_bind_data(info);
     idx_t column_count = duckdb_init_get_column_count(info);
 
-    bcf_global_init_data_t* global = (bcf_global_init_data_t*)duckdb_malloc(sizeof(bcf_global_init_data_t));
-    memset(global, 0, sizeof(bcf_global_init_data_t));
+    bcf_global_init_data_t* global = duckhts_alloc_array(1, sizeof(*global));
+    if (!global) {
+        duckdb_init_set_error(info, "read_bcf: out of memory allocating global state");
+        return;
+    }
 
     global->current_contig = 0;
     global->has_region = (bind->n_regions > 0);
@@ -1878,12 +1878,20 @@ static void bcf_read_local_init(duckdb_init_info info) {
     bcf_bind_data_t* bind = (bcf_bind_data_t*)duckdb_init_get_bind_data(info);
     const char *reader_name = "read_bcf";
 
-    bcf_init_data_t* local = (bcf_init_data_t*)duckdb_malloc(sizeof(bcf_init_data_t));
-    memset(local, 0, sizeof(bcf_init_data_t));
+    bcf_init_data_t* local = duckhts_alloc_array(1, sizeof(*local));
+    if (!local) {
+        duckdb_init_set_error(info, "read_bcf: out of memory allocating worker state");
+        return;
+    }
 
     local->column_count = duckdb_init_get_column_count(info);
     if (local->column_count > 0) {
-        local->column_ids = (idx_t*)duckdb_malloc(sizeof(idx_t) * local->column_count);
+        local->column_ids = duckhts_alloc_array(local->column_count, sizeof(*local->column_ids));
+        if (!local->column_ids) {
+            duckdb_init_set_error(info, "read_bcf: out of memory allocating projected columns");
+            destroy_init_data(local);
+            return;
+        }
         for (idx_t i = 0; i < local->column_count; i++) {
             local->column_ids[i] = duckdb_init_get_column_index(info, i);
         }
@@ -2500,7 +2508,9 @@ static void bcf_read_function(duckdb_function_info info, duckdb_data_chunk outpu
     // Cache vector pointers to reduce repeated calls
     duckdb_vector* vectors = NULL;
     if (init->column_count > 0) {
-        vectors = (duckdb_vector*)duckdb_malloc(init->column_count * sizeof(duckdb_vector));
+        if (init->column_count <= SIZE_MAX / sizeof(*vectors)) {
+            vectors = duckdb_malloc((size_t)init->column_count * sizeof(*vectors));
+        }
         if (!vectors) {
             duckdb_function_set_error(info, "read_bcf: out of memory allocating output vector pointers");
             duckdb_data_chunk_set_size(output, 0);

--- a/src/include/duckdb_alloc.h
+++ b/src/include/duckdb_alloc.h
@@ -1,0 +1,27 @@
+#ifndef DUCKHTS_DUCKDB_ALLOC_H
+#define DUCKHTS_DUCKDB_ALLOC_H
+
+#include <stdint.h>
+#include <string.h>
+
+/* Include after duckdb_extension.h and DUCKDB_EXTENSION_EXTERN. Storage is
+ * owned by the caller and released with duckdb_free. Empty arrays return NULL.
+ * Zero each allocation immediately so partial owners are safe to destroy. */
+static inline void *duckhts_alloc_array(idx_t count, size_t width) {
+    if (!count || !width || count > SIZE_MAX / width) return NULL;
+    size_t bytes = (size_t)count * width;
+    void *data = duckdb_malloc(bytes);
+    if (data) memset(data, 0, bytes);
+    return data;
+}
+
+static inline char *duckhts_copy_string(const char *text) {
+    if (!text) return NULL;
+    size_t length = strlen(text);
+    if (length == SIZE_MAX) return NULL;
+    char *copy = duckdb_malloc(length + 1);
+    if (copy) memcpy(copy, text, length + 1);
+    return copy;
+}
+
+#endif

--- a/src/seq_reader.c
+++ b/src/seq_reader.c
@@ -45,6 +45,7 @@ DUCKDB_EXTENSION_EXTERN
 #include <htslib/kstring.h>
 
 #include "include/hts_io_tuning.h"
+#include "include/duckdb_alloc.h"
 #include "include/region_list.h"
 #include "include/seq_encoding.h"
 #include "include/quality_encoding.h"
@@ -448,8 +449,12 @@ static void seq_read_bind(duckdb_bind_info info, int is_fastq) {
     }
     sam_close(fp);
 
-    seq_bind_data_t *bind = (seq_bind_data_t *)duckdb_malloc(sizeof(seq_bind_data_t));
-    memset(bind, 0, sizeof(seq_bind_data_t));
+    seq_bind_data_t *bind = duckhts_alloc_array(1, sizeof(*bind));
+    if (!bind) {
+        duckdb_bind_set_error(info, "FASTA/FASTQ: out of memory allocating bind state");
+        duckdb_free(file_path);
+        return;
+    }
     bind->file_path = file_path;
     bind->is_fastq = is_fastq;
     bind->direct_fastq = is_fastq && fmt == fastq_format;
@@ -656,13 +661,21 @@ static void fastq_read_bind(duckdb_bind_info info) { seq_read_bind(info, 1); }
 static void seq_read_init(duckdb_init_info info) {
     seq_bind_data_t *bind = (seq_bind_data_t *)duckdb_init_get_bind_data(info);
 
-    seq_init_data_t *init = (seq_init_data_t *)duckdb_malloc(sizeof(seq_init_data_t));
-    memset(init, 0, sizeof(seq_init_data_t));
+    seq_init_data_t *init = duckhts_alloc_array(1, sizeof(*init));
+    if (!init) {
+        duckdb_init_set_error(info, "FASTA/FASTQ: out of memory allocating worker state");
+        return;
+    }
 
     /* Projection pushdown: record which columns DuckDB actually needs */
     init->column_count = duckdb_init_get_column_count(info);
     if (init->column_count > 0) {
-        init->column_ids = (idx_t *)duckdb_malloc(sizeof(idx_t) * init->column_count);
+        init->column_ids = duckhts_alloc_array(init->column_count, sizeof(*init->column_ids));
+        if (!init->column_ids) {
+            duckdb_init_set_error(info, "FASTA/FASTQ: out of memory allocating projected columns");
+            destroy_seq_init(init);
+            return;
+        }
         for (idx_t i = 0; i < init->column_count; i++)
             init->column_ids[i] = duckdb_init_get_column_index(info, i);
     }
@@ -785,6 +798,11 @@ static void seq_read_init(duckdb_init_info info) {
     }
 
     init->rec = bam_init1();
+    if (!init->rec) {
+        duckdb_init_set_error(info, "FASTA/FASTQ: out of memory allocating sequence record");
+        destroy_seq_init(init);
+        return;
+    }
 
     if (bind->paired) {
         init->fp_mate = sam_open(bind->mate_path, "r");
@@ -802,6 +820,11 @@ static void seq_read_init(duckdb_init_info info) {
             return;
         }
         init->rec_mate = bam_init1();
+        if (!init->rec_mate) {
+            duckdb_init_set_error(info, "read_fastq: out of memory allocating mate record");
+            destroy_seq_init(init);
+            return;
+        }
     }
 
     if (!bind->is_fastq && bind->n_regions > 0) {

--- a/test/data/bam_read_groups.sam
+++ b/test/data/bam_read_groups.sam
@@ -1,0 +1,14 @@
+@HD	VN:1.6	SO:unknown
+@SQ	SN:chr1	LN:100
+@RG	ID:one	SM:sample_one
+@RG	ID:missing
+@RG	ID:three	SM:sample_three
+@CO	DuckHTS synthetic fixture: repeated, missing, unknown, and changing read groups.
+r1	0	chr1	1	60	1M	*	0	0	A	I	RG:Z:one
+r2	0	chr1	2	60	1M	*	0	0	C	I	RG:Z:one
+r3	0	chr1	3	60	1M	*	0	0	G	I	RG:Z:missing
+r4	0	chr1	4	60	1M	*	0	0	T	I	RG:Z:missing
+r5	0	chr1	5	60	1M	*	0	0	A	I	RG:Z:three
+r6	0	chr1	6	60	1M	*	0	0	C	I
+r7	0	chr1	7	60	1M	*	0	0	G	I	RG:Z:unknown
+r8	0	chr1	8	60	1M	*	0	0	T	I	RG:Z:one

--- a/test/data/default_gt.vcf
+++ b/test/data/default_gt.vcf
@@ -1,0 +1,5 @@
+##fileformat=VCFv4.3
+##source=DuckHTS_synthetic_header_light_GT_fallback
+##contig=<ID=chr1,length=100>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1
+chr1	1	fallback	A	C	.	PASS	.	GT	0/1

--- a/test/scripts/reader_alloc_probe.c
+++ b/test/scripts/reader_alloc_probe.c
@@ -1,0 +1,124 @@
+/* Test-only interposition on the loaded extension's copied DuckDB API table.
+ * Never replace the host allocator or expose a production fault-injection API.
+ * The driver must run one query at a time with SET threads=1. */
+#define _GNU_SOURCE
+#include "duckdb_extension.h"
+#include <dlfcn.h>
+#include <stdlib.h>
+
+static duckdb_ext_api_v1 duckdb_ext_api;
+#include "duckdb_alloc.h"
+#undef duckdb_malloc
+#undef duckdb_free
+
+static duckdb_ext_api_v1 *extension_api;
+static void *extension_handle;
+static void *(*saved_malloc)(size_t);
+static void (*saved_free)(void *);
+static void *live[16384];
+static long live_count, attempts, fail_at, failures;
+
+static void *probe_malloc(size_t bytes) {
+    attempts++;
+    if (attempts == fail_at) {
+        failures++;
+        return NULL;
+    }
+    void *data = saved_malloc(bytes);
+    if (!data) abort(); /* An uncontrolled OOM is not the injected failure. */
+    for (size_t i = 0; i < sizeof(live) / sizeof(*live); i++) {
+        if (!live[i]) {
+            live[i] = data;
+            live_count++;
+            return data;
+        }
+    }
+    abort(); /* Test ledger capacity is not a reader resource limit. */
+}
+
+static void probe_free(void *data) {
+    if (data) {
+        for (size_t i = 0; i < sizeof(live) / sizeof(*live); i++) {
+            if (live[i] == data) {
+                live[i] = NULL;
+                live_count--;
+                break;
+            }
+        }
+    }
+    /* Also release host-created values (e.g. duckdb_get_varchar results),
+     * which are deliberately outside the first-party allocation ledger. */
+    saved_free(data);
+}
+
+int reader_alloc_open(const char *path) {
+    extension_handle = dlopen(path, RTLD_NOW | RTLD_NOLOAD);
+    if (!extension_handle) return 1;
+    extension_api = dlsym(extension_handle, "duckdb_ext_api");
+    if (!extension_api) return 2;
+    saved_malloc = extension_api->duckdb_malloc;
+    saved_free = extension_api->duckdb_free;
+    return !saved_malloc || !saved_free;
+}
+
+int reader_alloc_arm(long nth) {
+    if (!extension_api || live_count) return 1;
+    attempts = failures = 0;
+    fail_at = nth;
+    extension_api->duckdb_malloc = probe_malloc;
+    extension_api->duckdb_free = probe_free;
+    return 0;
+}
+
+long reader_alloc_attempts(void) { return attempts; }
+long reader_alloc_failures(void) { return failures; }
+long reader_alloc_live(void) { return live_count; }
+
+void reader_alloc_disarm(void) {
+    extension_api->duckdb_malloc = saved_malloc;
+    extension_api->duckdb_free = saved_free;
+}
+
+void reader_alloc_close(void) {
+    reader_alloc_disarm();
+    dlclose(extension_handle);
+    extension_handle = NULL;
+    extension_api = NULL;
+}
+
+int reader_alloc_helper_checks(void) {
+    duckdb_ext_api.duckdb_malloc = probe_malloc;
+    long before = attempts;
+    if (duckhts_alloc_array(UINT64_MAX, 2) || duckhts_alloc_array(0, 1) ||
+        duckhts_alloc_array(1, 0) || attempts != before) return 1;
+    unsigned char *bytes = duckhts_alloc_array(3, 7);
+    if (!bytes) return 2;
+    for (int i = 0; i < 21; i++) {
+        if (bytes[i]) return 3;
+    }
+    probe_free(bytes);
+    char *text = duckhts_copy_string("sample");
+    if (!text || strcmp(text, "sample")) return 4;
+    probe_free(text);
+    fail_at = attempts + 1;
+    if (duckhts_alloc_array(1, 7)) return 5;
+    fail_at = attempts + 1;
+    if (duckhts_copy_string("sample")) return 6;
+    return live_count != 0;
+}
+
+/* R's .C passes addresses; these adapters exercise the installed package's
+ * separately built extension without depending on R headers or changing it. */
+void reader_alloc_r_open(char **path, int *status) {
+    *status = reader_alloc_open(*path);
+}
+
+void reader_alloc_r_arm(int *nth, int *status) {
+    *status = reader_alloc_arm(*nth);
+}
+
+void reader_alloc_r_stats(int *count, int *remaining, int *failed) {
+    *count = (int)attempts;
+    *remaining = (int)live_count;
+    *failed = (int)failures;
+}

--- a/test/scripts/reader_alloc_test.R
+++ b/test/scripts/reader_alloc_test.R
@@ -1,0 +1,63 @@
+#!/usr/bin/env Rscript
+# POSIX fault-injection complement to installed-package tinytest contracts.
+# Usage: Rscript test/scripts/reader_alloc_test.R /path/to/test-only/probe.so
+library(DBI)
+library(Rduckhts)
+
+test_installed_reader_allocations <- function(probe_path) {
+  shim <- dyn.load(normalizePath(probe_path, mustWork = TRUE))
+  on.exit(dyn.unload(shim[["path"]]), add = TRUE, after = FALSE)
+  con <- rduckhts_connect(config = list(threads = "1"))
+  on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE, after = FALSE)
+  extension <- system.file("duckhts_extension", "build", "duckhts.duckdb_extension", package = "Rduckhts")
+  status <- .C("reader_alloc_r_open", extension, status = 0L, PACKAGE = shim[["name"]])$status
+  stopifnot(status == 0L)
+  on.exit(.C("reader_alloc_close", PACKAGE = shim[["name"]]), add = TRUE, after = FALSE)
+  arm <- function(nth) {
+    stopifnot(.C("reader_alloc_r_arm", as.integer(nth), status = 0L,
+                PACKAGE = shim[["name"]])$status == 0L)
+  }
+  stats <- function() .C("reader_alloc_r_stats", count = 0L, remaining = 0L,
+                         failed = 0L, PACKAGE = shim[["name"]])
+  disarm <- function() invisible(.C("reader_alloc_disarm", PACKAGE = shim[["name"]]))
+  fixtures <- c(read_bcf = "bcf_cache_lifecycle.vcf", read_bam = "bam_read_groups.sam",
+                read_fasta = "region_names.fa", read_fastq = "r1.fq")
+  failures <- 0L
+  for (reader in names(fixtures)) {
+    path <- system.file("extdata", fixtures[[reader]], package = "Rduckhts")
+    stopifnot(nzchar(path))
+    options <- if (reader == "read_bam") ", decompression_threads := 0" else ""
+    # Non-BGZF FILE_OFFSET is a separate transport defect, not a SAM field.
+    # https://github.com/RGenomicsETL/duckhts/issues/194
+    projection <- if (reader == "read_bam") "* EXCLUDE(FILE_OFFSET)" else "*"
+    sql <- sprintf("SELECT %s FROM %s(%s, scan_mode := 'sequential'%s)",
+                   projection, reader, dbQuoteString(con, path), options)
+    arm(0L)
+    expected <- dbGetQuery(con, sql)
+    dbGetQuery(con, "SELECT 4242")
+    gc() # DBI prepared-result external pointers are finalized by R.
+    control <- stats()
+    stopifnot(control$count > 0L, control$remaining == 0L)
+    disarm()
+    for (nth in seq_len(control$count)) {
+      cat(reader, "fail", nth, "of", control$count, "\n")
+      arm(nth)
+      error <- tryCatch({dbGetQuery(con, sql); NULL}, error = identity)
+      stopifnot(inherits(error, "error"), grepl("out of memory", conditionMessage(error), fixed = TRUE))
+      stopifnot(dbGetQuery(con, "SELECT 4242 AS n")$n == 4242L)
+      gc()
+      state <- stats()
+      stopifnot(state$failed == 1L, state$remaining == 0L)
+      disarm()
+      stopifnot(identical(dbGetQuery(con, sql), expected))
+      dbGetQuery(con, "SELECT 4242")
+      failures <- failures + 1L
+    }
+  }
+  cat("Installed R reader allocation failures:", failures,
+      "errors, zero tracked leaks, exact DBI recovery: OK\n")
+}
+
+args <- commandArgs(trailingOnly = TRUE)
+stopifnot(length(args) == 1L)
+test_installed_reader_allocations(args[[1L]])

--- a/test/scripts/reader_alloc_test.py
+++ b/test/scripts/reader_alloc_test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Fail every direct DuckHTS duckdb_malloc call on real reader query paths.
+
+The shim is test-only and POSIX-only; no global malloc interposition. Exact
+successful schemas/rows must survive recovery. The ledger covers first-party
+DuckDB-owned allocations, not HTSlib/libc buffers or DuckDB output storage.
+ASan/UBSan additionally check invalid access and cleanup in the full extension.
+"""
+import argparse
+import ctypes
+from pathlib import Path
+
+import duckdb
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--extension", required=True, type=Path)
+    parser.add_argument("--probe", required=True, type=Path)
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[2]
+
+    def source(reader, fixture, options=""):
+        path = str(root / "test/data" / fixture).replace("'", "''")
+        return f"{reader}('{path}'{options})"
+
+    cases = {
+        "bcf-indexed-wide": source("read_bcf", "vcf_file.bcf"),
+        "bcf-sequential-wide": source("read_bcf", "bcf_cache_lifecycle.vcf", ", scan_mode:='sequential'"),
+        "bcf-tidy": source("read_bcf", "bcf_cache_lifecycle.vcf", ", tidy_format:=true"),
+        "bcf-fallback-gt": source("read_bcf", "default_gt.vcf"),
+        "bcf-regions": source("read_bcf", "region_union.bcf", ", region:='chr1:11-11,chr1:19-19'"),
+        "vcf-tabix": source("read_bcf", "region_union.vcf.gz"),
+        "bam-indexed": source("read_bam", "bam_scan_mixed.bam", ", decompression_threads:=0"),
+        "bam-read-groups": source("read_bam", "bam_read_groups.sam", ", scan_mode:='sequential', decompression_threads:=0"),
+        "cram-indexed": source("read_bam", "bam_scan_mixed.cram", ", decompression_threads:=0"),
+        "fasta-sequential": source("read_fasta", "region_names.fa", ", scan_mode:='sequential'"),
+        "fasta-indexed": source("read_fasta", "region_names.fa.gz", ", region:='{chr,part}:1-5,{chr:part}:1-5'"),
+        "fastq": source("read_fastq", "r1.fq"),
+        "fastq-paired": source("read_fastq", "r1.fq", ", mate_path:='" + str(root / "test/data/r2.fq") + "'"),
+    }
+    con = duckdb.connect(config={"allow_unsigned_extensions": "true", "threads": "1"})
+    extension = str(args.extension.resolve())
+    con.execute("LOAD '" + extension.replace("'", "''") + "'")
+    probe = ctypes.CDLL(str(args.probe.resolve()))
+    probe.reader_alloc_open.argtypes = [ctypes.c_char_p]
+    probe.reader_alloc_arm.argtypes = [ctypes.c_long]
+    for name in ("attempts", "failures", "live"):
+        getattr(probe, "reader_alloc_" + name).restype = ctypes.c_long
+    assert probe.reader_alloc_open(extension.encode()) == 0
+    assert probe.reader_alloc_arm(0) == 0
+    assert probe.reader_alloc_helper_checks() == 0
+    probe.reader_alloc_disarm()
+
+    def read(sql):
+        result = con.execute(sql)
+        schema = [(col[0], str(col[1])) for col in result.description]
+        rows = result.fetchall()
+        # Full physical multiset: no implicit order promise for parallel readers.
+        return schema, sorted(rows, key=repr)
+
+    failures = 0
+    try:
+        for name, relation in cases.items():
+            for projection in ("*", "count(*)"):
+                # FILE_OFFSET currently misreads non-BGZF SAM/CRAM handles.
+                # https://github.com/RGenomicsETL/duckhts/issues/194
+                # That separate transport defect is not a recovery oracle;
+                # retain every biological field, including SAMPLE_ID.
+                if name in ("cram-indexed", "bam-read-groups") and projection == "*":
+                    projection = "* EXCLUDE(FILE_OFFSET)"
+                sql = f"SELECT {projection} FROM {relation}"
+                assert probe.reader_alloc_arm(0) == 0
+                expected = read(sql)
+                con.execute("SELECT 4242").fetchall()  # release the prior result
+                count = probe.reader_alloc_attempts()
+                assert probe.reader_alloc_live() == 0, (name, "control leak")
+                probe.reader_alloc_disarm()
+                assert count > 0, (name, "probe did not intercept allocations")
+                for nth in range(1, count + 1):
+                    print(f"{name} {projection}: fail {nth}/{count}", flush=True)
+                    assert probe.reader_alloc_arm(nth) == 0
+                    try:
+                        read(sql)
+                    except duckdb.Error as error:
+                        assert "out of memory" in str(error).lower(), (name, nth, error)
+                    else:
+                        raise AssertionError((name, nth, "allocation failure silently succeeded"))
+                    assert probe.reader_alloc_failures() == 1, (name, nth, "injection missed")
+                    assert con.execute("SELECT 4242").fetchone() == (4242,)
+                    assert probe.reader_alloc_live() == 0, (name, nth, "first-party leak")
+                    probe.reader_alloc_disarm()
+                    assert read(sql) == expected, (name, nth, "recovery changed schema/rows")
+                    con.execute("SELECT 4242").fetchall()
+                    failures += 1
+    finally:
+        probe.reader_alloc_close()
+        con.close()
+    print(f"reader allocation failures: {failures} errors, zero tracked leaks, exact schema/row recovery: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/sql/bam_scan.test
+++ b/test/sql/bam_scan.test
@@ -4,6 +4,22 @@
 
 require duckhts
 
+# Missing SM, absent/unknown RG, and cache transitions are distinct from OOM.
+query TTT
+SELECT QNAME, READ_GROUP_ID, SAMPLE_ID
+FROM read_bam('__WORKING_DIRECTORY__/test/data/bam_read_groups.sam',
+              scan_mode := 'sequential', decompression_threads := 0)
+ORDER BY QNAME;
+----
+r1	one	sample_one
+r2	one	sample_one
+r3	missing	NULL
+r4	missing	NULL
+r5	three	sample_three
+r6	NULL	NULL
+r7	unknown	NULL
+r8	one	sample_one
+
 statement ok
 SET threads=1;
 


### PR DESCRIPTION
## Summary

Closes https://github.com/RGenomicsETL/duckhts/issues/189.

- Check BAM/BCF/FASTA/FASTQ bind/global/worker acquisition and input-driven array arithmetic. A small shared DuckDB-owned zero-array/string helper makes partially constructed owners safe to destroy; no allocator framework or public fault-injection API.
- Reject incomplete BCF sample/INFO/FORMAT/contig metadata instead of publishing partial schemas. Zero FORMAT projection-group owners before subsequent allocations can fail, and check the supported column count.
- Delete BAM's redundant sample-string copy. Reuse the worker-owned HTSlib lookup string, check RG caching and distinguish missing SM from HTSlib lookup failure. Preserve per-worker HTSlib/faidx ownership, reader scheduling, schemas, and scan semantics.
- Update both changelogs, add SQL/installed-package missing-RG/SM tests, and keep the fault shim outside the production extension and R package.

## Validation

- `make release -j2`, `make test_release`: all 37 SQL files and existing native kernel/property/fuzz/reference-cache gates pass; existing seeds, trial counts, biological oracles and denominators are unchanged.
- 445 deterministic first-party `duckdb_malloc` failures across 13 reader paths, with full projection and counting controls. Every injected failure is a query error, with zero tracked first-party allocations and exact schema/row-multiset recovery on the same connection. The identical probe crashes the pre-fix binary at its first injected allocation (negative control).
- Complete-extension ASan and UBSan gates pass, including all 445 injections. The Python ASan runtime preloads libstdc++ so the C++ exception interceptor is available before importing DuckDB; no sanitizer check is disabled beyond the existing host-runtime leak-check setting.
- Mandatory package bootstrap and tarball installation: all 2,363 tinytest results pass. `make test-reader-alloc-r` additionally exercises 52 injected failures against the separately built installed extension, with exact DBI recovery and zero tracked allocations after R finalizes prepared-result external pointers.
- Paired pre-fix/current controls retain exact BCF wide/tidy, BAM SAMPLE_ID, indexed FASTA and FASTQ schemas/biological row multisets. Shared faidx/reference-cache tests remain intact.
- Native-probe target selection checked for Linux, Windows and Wasm; `git diff --check` passes.
- Fixed the initial Linux outside-Docker CI failure: the test shim now compiles in a fresh host temporary directory instead of reopening a container-absolute CMake cache. Both 445 Python / 52 installed-R injections still pass; the Python target also passes from a relocated test tree containing no CMake build directory. No reader source, workload, or test assertion changed for this CI fix.

The allocation ledger covers DuckHTS's direct DuckDB-owned allocations, not HTSlib/libc buffers or DuckDB output memory. This is not a whole-reader no-allocation/no-leak certificate. Separate concrete defects discovered during review remain open: [materialization errors](https://github.com/RGenomicsETL/duckhts/issues/193) and [non-BGZF FILE_OFFSET](https://github.com/RGenomicsETL/duckhts/issues/194). SAM/CRAM biological-row recovery checks exclude that independently broken transport diagnostic; no biological fields or multiplicities are excluded.

## Performance

Checked-in rendered reports compare source `da5daa2cdd75aa9a920bf6a71f18174661b15198` with `05fcdfdfcb32eb94a987d946e65d377040644c1a` (candidate `src` tree `b7e5c3bbd984e0e339780d71d6324098622d2fa5`). They record binary/input identities and the same-run pre-change workload; report/Makefile-only commits do not change the measured source tree.

- [Full typed BCF materialization](https://github.com/RGenomicsETL/duckhts/blob/1bfebde5407fd63987cda0fada49509b16beb129/benchmarks/benchmark_reader_allocations.md), rendered from `benchmark_bcf_record_cache.Rmd`: registered GIAB HG002 GRCh38 NIST v4.2.1 input; 4,048,342 input records and 4,048,342 materialized rows, one sample, 29 wide / 30 tidy columns; one DuckDB worker and zero HTSlib decompression workers. Three repetitions per mode/build in fresh R/DuckDB processes, CPU affinity 0,2,4,6. Median baseline → candidate: wide 16.977 → 14.592 s; tidy 15.339 → 14.797 s. Every repetition validates the independent record count and all-field checksum; first-run complete typed row multisets compare exactly with EXCEPT ALL both ways. The [nearest recorded identical GIAB workload](https://github.com/RGenomicsETL/duckhts/blob/da5daa2cdd75aa9a920bf6a71f18174661b15198/benchmarks/benchmark_bcf_reader_retirement.md), source `8b8458a70b156694160bdb81a21fb8527e2a6582`, recorded 14.611 / 14.821 s wide/tidy; all raw current repetitions are retained, including variation in the immediate pre-change baseline. These observations do not isolate a causal speedup from error checks.
- [Automatic BAM full-file scan](https://github.com/RGenomicsETL/duckhts/blob/1bfebde5407fd63987cda0fada49509b16beb129/benchmarks/benchmark_bam_tail_scan.md), re-rendered from its Rmd: committed nanopore fixture, 186 input records / 249,110 bases, 186 decoded sequence rows and one SQL aggregate row; one/four DuckDB workers, two HTSlib workers per handle, auto AVX2, nine repetitions after warm-up. Median baseline → candidate: 1.684 → 1.561 ms at one worker; 2.069 → 2.239 ms at four workers. The [nearest recorded identical workload](https://github.com/RGenomicsETL/duckhts/blob/da5daa2cdd75aa9a920bf6a71f18174661b15198/benchmarks/benchmark_bam_tail_scan.md), source `67db30ac9dc40d0de4f6bb8ae55c6cfa3ea48011`, recorded 1.340 / 1.810 ms at one/four workers. This is a setup-dominated small fixture with variable timings, not a WGS throughput or general regression certificate; the older large exome report uses a different input and is not treated as comparable.

No checked-in benchmark exercises the modified RG-to-SAMPLE_ID cache or FASTA/FASTQ construction costs. The BAM SEQ report is the nearest baseline; RG-heavy sample lookup and representative FASTA/FASTQ timings remain missing. These measurements do not cover remote I/O, many-sample/CSQ throughput, or static allocation, and make no fastest-reader/general-parity claim.

## Merge requirements

All 21 current-head CI checks passed for `71e35468ad7811733f9f107ea021bd5ec78a058a`. [Codex review of that head](https://github.com/RGenomicsETL/duckhts/pull/195#issuecomment-5554998791) found no major issues and explicitly names reviewed commit `71e35468ad`. Work is on `develop`; no feature branch. The earlier review of `1bfebde540` was not used to satisfy the final-head gate.
