### PR TITLE
Fail BCF indexed scans when the worker index disappears

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # DuckHTS Extension News
 
 # duckhts 1.5.1.9000
+- fail index-dependent BCF/VCF parallel scans when a worker cannot reload its
+  index, instead of silently returning zero rows. Preserve sequential fallback
+  when no index was available at bind, and same-connection recovery after errors
+
 - replace the BAM SIMD benchmark's Python driver with a shared R driver and
   fresh R/DuckDB processes per backend; retain workload controls and result
   checks, and invalidate cached measurements when binaries or inputs change

--- a/benchmarks/benchmark_bcf_scan_init.Rmd
+++ b/benchmarks/benchmark_bcf_scan_init.Rmd
@@ -1,0 +1,105 @@
+---
+title: "Indexed BCF/VCF scan initialization: small-fixture cost"
+output:
+  github_document:
+    html_preview: false
+---
+
+This paired measurement exercises automatic contig scanning with a usable
+worker index. Each committed fixture contains two records on one occupied
+contig and 256 empty header contigs. It measures setup and materialization
+latency, not cohort throughput. The separate SQL/R regressions corrupt or remove
+a private index after preparing a query and require an error instead of zero rows.
+
+The nearest larger full-column report is
+[`benchmark_reader_allocations.md`](benchmark_reader_allocations.md):
+4,048,342 GIAB HG002 records in wide/tidy form, one sequential scan handle and
+zero HTSlib decompression workers. It does not exercise automatic parallel
+index reloads and is not an identical-workload baseline. This first small-fixture
+scan-init report measures the pre-fix binary alongside the candidate.
+
+## Reproduction and identity
+
+Set `BCF_SCAN_BASELINE_EXTENSION` and `BCF_SCAN_BASELINE_REVISION` to a separately
+built baseline. `DUCKHTS_EXTENSION` selects the candidate. From the repository root:
+
+```sh
+taskset -c 0,2,4,6 Rscript -e 'rmarkdown::render("benchmarks/benchmark_bcf_scan_init.Rmd")'
+```
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
+knitr::opts_knit$set(root.dir = normalizePath(".."))
+```
+
+```{r measurement}
+baseline <- Sys.getenv("BCF_SCAN_BASELINE_EXTENSION")
+baseline_revision <- Sys.getenv("BCF_SCAN_BASELINE_REVISION")
+candidate <- Sys.getenv("DUCKHTS_EXTENSION", "build/release/duckhts.duckdb_extension")
+stopifnot(nzchar(baseline_revision), file.exists(baseline), file.exists(candidate))
+stopifnot(system2("git", c("diff", "--quiet", "HEAD", "--", "src")) == 0L)
+identity <- data.frame(
+  property = c("baseline revision", "candidate revision", "candidate src tree",
+               "baseline binary MD5", "candidate binary MD5", "R", "DuckDB R package",
+               "HTSlib", "CPU affinity", "repetitions"),
+  value = c(baseline_revision, system2("git", c("rev-parse", "HEAD"), stdout = TRUE),
+            system2("git", c("rev-parse", "HEAD:src"), stdout = TRUE),
+            unname(tools::md5sum(baseline)), unname(tools::md5sum(candidate)),
+            R.version.string, as.character(packageVersion("duckdb")),
+            readLines("third_party/htslib/VERSION", n = 1),
+            system2("taskset", c("-pc", Sys.getpid()), stdout = TRUE),
+            "9 timed calls after warm-up; fresh R process per build/input/thread setting")
+)
+knitr::kable(identity)
+inputs <- paste0("test/data/parallel_empty_contigs.", c("bcf", "vcf.gz"))
+indexes <- paste0(inputs, c(".csi", ".tbi"))
+stopifnot(all(file.exists(indexes)),
+          sum(grepl("^##contig=", readLines("test/data/parallel_empty_contigs.vcf"))) == 257L)
+knitr::kable(data.frame(file = c(inputs, indexes), bytes = file.info(c(inputs, indexes))$size,
+                        md5 = unname(tools::md5sum(c(inputs, indexes)))))
+results <- list()
+expected <- NULL
+for (input in inputs) for (threads in c(1L, 4L)) for (build in c("baseline", "candidate")) {
+  measured <- callr::r(function(extension, input, threads) {
+    con <- DBI::dbConnect(duckdb::duckdb(config = list(allow_unsigned_extensions = "true")))
+    on.exit(DBI::dbDisconnect(con, shutdown = TRUE))
+    DBI::dbExecute(con, paste("LOAD", DBI::dbQuoteString(con, extension)))
+    DBI::dbExecute(con, sprintf("SET threads=%d", threads))
+    sql <- sprintf("CREATE OR REPLACE TEMP TABLE scanned AS SELECT * FROM read_bcf(%s, decompression_threads:=0)",
+                   DBI::dbQuoteString(con, input))
+    DBI::dbExecute(con, sql)
+    expected <- DBI::dbGetQuery(con, "SELECT * FROM scanned ORDER BY ALL")
+    stopifnot(nrow(expected) == 2L, identical(as.numeric(expected$POS), c(10, 40)))
+    timings <- numeric(9)
+    for (i in seq_along(timings)) {
+      start <- Sys.time()
+      DBI::dbExecute(con, sql)
+      timings[i] <- as.numeric(difftime(Sys.time(), start, units = "secs"))
+      stopifnot(identical(DBI::dbGetQuery(con, "SELECT * FROM scanned ORDER BY ALL"), expected))
+    }
+    list(rows = expected, timings = timings)
+  }, args = list(extension = normalizePath(if (build == "baseline") baseline else candidate),
+                 input = normalizePath(input), threads = threads))
+  if (is.null(expected)) expected <- measured$rows
+  stopifnot(identical(expected, measured$rows))
+  results[[length(results) + 1L]] <- data.frame(
+    build, format = if (endsWith(input, ".bcf")) "BCF/CSI" else "VCF.gz/TBI",
+    duckdb_threads = threads, htslib_workers_per_handle = 0L,
+    header_contigs = 257L, input_records = 2L, materialized_rows = nrow(measured$rows),
+    materialized_columns = ncol(measured$rows), median_ms = 1000 * median(measured$timings),
+    min_ms = 1000 * min(measured$timings), max_ms = 1000 * max(measured$timings)
+  )
+}
+knitr::kable(do.call(rbind, results), digits = 3)
+```
+
+Each timed `CREATE OR REPLACE TEMP TABLE AS SELECT *` produces two complete
+materialized rows, not merely a count. Elapsed `Sys.time()` includes the DBI call;
+connection creation, warm-up, and complete typed-row verification are outside the
+timer. All repetitions, formats, thread settings and builds agree exactly on those
+rows, including GT and ALT, without asserting scan arrival order.
+
+This does not measure the latency of an index failure, remote I/O, large-cohort
+throughput, RSS, or maximum worker concurrency. Thread settings are DuckDB's
+requested limits. Small timings can vary with scheduling; no general speedup or
+no-regression claim follows from them.

--- a/benchmarks/benchmark_bcf_scan_init.md
+++ b/benchmarks/benchmark_bcf_scan_init.md
@@ -1,0 +1,70 @@
+Indexed BCF/VCF scan initialization: small-fixture cost
+================
+
+This paired measurement exercises automatic contig scanning with a
+usable worker index. Each committed fixture contains two records on one
+occupied contig and 256 empty header contigs. It measures setup and
+materialization latency, not cohort throughput. The separate SQL/R
+regressions corrupt or remove a private index after preparing a query
+and require an error instead of zero rows.
+
+The nearest larger full-column report is
+[`benchmark_reader_allocations.md`](benchmark_reader_allocations.md):
+4,048,342 GIAB HG002 records in wide/tidy form, one sequential scan
+handle and zero HTSlib decompression workers. It does not exercise
+automatic parallel index reloads and is not an identical-workload
+baseline. This first small-fixture scan-init report measures the pre-fix
+binary alongside the candidate.
+
+## Reproduction and identity
+
+Set `BCF_SCAN_BASELINE_EXTENSION` and `BCF_SCAN_BASELINE_REVISION` to a
+separately built baseline. `DUCKHTS_EXTENSION` selects the candidate.
+From the repository root:
+
+``` sh
+taskset -c 0,2,4,6 Rscript -e 'rmarkdown::render("benchmarks/benchmark_bcf_scan_init.Rmd")'
+```
+
+| property             | value                                                                       |
+|:---------------------|:----------------------------------------------------------------------------|
+| baseline revision    | 536cf59425fe5be9aa4e2518feaadd226901146b                                    |
+| candidate revision   | f06064bade5bd6dadcd6dceffb92669155a6d913                                    |
+| candidate src tree   | e906cdc916567d4c995a52f2bf7d14267c0f2e48                                    |
+| baseline binary MD5  | 5296739913e78217f12229647f5299a5                                            |
+| candidate binary MD5 | 0d03c255a6609e1b67a36672c0b4168c                                            |
+| R                    | R version 4.6.0 (2026-04-24)                                                |
+| DuckDB R package     | 1.5.3                                                                       |
+| HTSlib               | 1.24                                                                        |
+| CPU affinity         | pid 970927’s current affinity list: 0,2,4,6                                 |
+| repetitions          | 9 timed calls after warm-up; fresh R process per build/input/thread setting |
+
+| file                                        | bytes | md5                              |
+|:--------------------------------------------|------:|:---------------------------------|
+| test/data/parallel_empty_contigs.bcf        |  1351 | e7576013a2a4cfc843130eff617ea527 |
+| test/data/parallel_empty_contigs.vcf.gz     |   372 | 8583a37cb25fe73d7dc8925652804942 |
+| test/data/parallel_empty_contigs.bcf.csi    |   117 | 1cb71253d787009c2867430c349f2769 |
+| test/data/parallel_empty_contigs.vcf.gz.tbi |   106 | 9f978fe03cf1a2d047683b8c2e578eae |
+
+| build     | format     | duckdb_threads | htslib_workers_per_handle | header_contigs | input_records | materialized_rows | materialized_columns | median_ms | min_ms | max_ms |
+|:----------|:-----------|---------------:|--------------------------:|---------------:|--------------:|------------------:|---------------------:|----------:|-------:|-------:|
+| baseline  | BCF/CSI    |              1 |                         0 |            257 |             2 |                 2 |                    8 |     1.203 |  1.162 |  1.338 |
+| candidate | BCF/CSI    |              1 |                         0 |            257 |             2 |                 2 |                    8 |     1.161 |  1.138 |  1.296 |
+| baseline  | BCF/CSI    |              4 |                         0 |            257 |             2 |                 2 |                    8 |     1.254 |  1.217 |  1.486 |
+| candidate | BCF/CSI    |              4 |                         0 |            257 |             2 |                 2 |                    8 |     1.217 |  1.197 |  1.329 |
+| baseline  | VCF.gz/TBI |              1 |                         0 |            257 |             2 |                 2 |                    8 |     0.952 |  0.884 |  1.076 |
+| candidate | VCF.gz/TBI |              1 |                         0 |            257 |             2 |                 2 |                    8 |     0.902 |  0.890 |  0.978 |
+| baseline  | VCF.gz/TBI |              4 |                         0 |            257 |             2 |                 2 |                    8 |     0.925 |  0.885 |  0.986 |
+| candidate | VCF.gz/TBI |              4 |                         0 |            257 |             2 |                 2 |                    8 |     0.902 |  0.864 |  0.995 |
+
+Each timed `CREATE OR REPLACE TEMP TABLE AS SELECT *` produces two
+complete materialized rows, not merely a count. Elapsed `Sys.time()`
+includes the DBI call; connection creation, warm-up, and complete
+typed-row verification are outside the timer. All repetitions, formats,
+thread settings and builds agree exactly on those rows, including GT and
+ALT, without asserting scan arrival order.
+
+This does not measure the latency of an index failure, remote I/O,
+large-cohort throughput, RSS, or maximum worker concurrency. Thread
+settings are DuckDB’s requested limits. Small timings can vary with
+scheduling; no general speedup or no-regression claim follows from them.

--- a/r/Rduckhts/NEWS.md
+++ b/r/Rduckhts/NEWS.md
@@ -1,5 +1,9 @@
 
 # Rduckhts 1.5.1.9000-0.1.5
+- make a missing or corrupt worker index a bundled BCF/VCF query error when
+  bind selected parallel scanning; preserve ordinary no-index fallback and
+  same-connection recovery rather than silently losing records
+
 - make bundled BAM formatting and list-growth failures DBI query errors,
   preserving same-connection recovery and genuine missing/empty values instead
   of returning fabricated CIGAR or partial auxiliary tags. Size integer-array

--- a/r/Rduckhts/inst/duckhts_extension/bcf_reader.c
+++ b/r/Rduckhts/inst/duckhts_extension/bcf_reader.c
@@ -1992,6 +1992,15 @@ static void bcf_read_local_init(duckdb_init_info info) {
         }
     }
 
+    /* Bind already chose one-owner-per-contig scanning. Without the worker's
+     * index, every contig would look empty; streaming fallback would duplicate
+     * the file across workers. Fail this plan instead. */
+    if (is_parallel && !local->idx && !local->tbx) {
+        duckdb_init_set_error(info, "read_bcf: failed to reload index for parallel scan");
+        destroy_init_data(local);
+        return;
+    }
+
     // Set up region query if user specified a region (non-parallel case)
     if (!is_parallel && bind->n_regions > 0) {
         // First check if we have an index

--- a/r/Rduckhts/inst/tinytest/test_bcf.R
+++ b/r/Rduckhts/inst/tinytest/test_bcf.R
@@ -373,6 +373,47 @@ test_bcf_record_cache <- function() {
   expect_equal(out$correct[[1]], 2053)
 }
 
+test_bcf_index_reload <- function() {
+  con <- rduckhts_connect()
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+  index <- tempfile("duckhts-bcf-index-")
+  hidden <- paste0(index, ".hidden")
+  on.exit(unlink(c(index, hidden)), add = TRUE)
+  for (file in c("parallel_empty_contigs.bcf", "parallel_empty_contigs.vcf.gz")) {
+    path <- system.file("extdata", file, package = "Rduckhts")
+    expect_true(nzchar(path))
+    build <- sprintf("SELECT * FROM bcf_index(%s, index_path := %s, threads := 1)",
+                     dbQuoteString(con, path), dbQuoteString(con, index))
+    for (workers in c(1L, 4L)) for (tidy in c(FALSE, TRUE)) for (damage in c("missing", "corrupt")) {
+      dbExecute(con, sprintf("SET threads=%d", workers))
+      dbGetQuery(con, build)
+      source <- sprintf("read_bcf(%s, index_path := %s, tidy_format := %s, decompression_threads := 0",
+                        dbQuoteString(con, path), dbQuoteString(con, index), tolower(tidy))
+      # R DuckDB's EXECUTE bookkeeping coerces the first column to numeric.
+      # Keep POS first while retaining every column for exact row comparison.
+      projection <- "SELECT POS, * EXCLUDE (POS) FROM "
+      sql <- paste0(projection, source, ") ORDER BY CHROM, POS")
+      expected <- dbGetQuery(con, sql)
+      expect_equal(nrow(expected), 2L)
+      dbExecute(con, paste("PREPARE index_scan AS", sql))
+      if (damage == "missing") {
+        expect_true(file.rename(index, hidden))
+      } else writeLines("broken index", index)
+      expect_error(dbGetQuery(con, "EXECUTE index_scan"),
+                   pattern = "read_bcf: failed to reload index for parallel scan")
+      expect_equal(dbGetQuery(con, "SELECT 4242 AS n")$n, 4242L)
+      expect_equal(dbGetQuery(con, sql), expected) # New bind: no-index fallback.
+      sequential <- paste0(projection, source, ", scan_mode := 'sequential') ORDER BY CHROM, POS")
+      expect_equal(dbGetQuery(con, sequential), expected)
+      dbGetQuery(con, build)
+      expect_equal(dbGetQuery(con, "EXECUTE index_scan"), expected)
+      dbExecute(con, "DEALLOCATE index_scan")
+      if (file.exists(hidden)) unlink(hidden)
+    }
+  }
+}
+
+test_bcf_index_reload()
 test_bcf_record_cache()
 test_bcf_string_format_lists()
 test_bcf_projection_sql()

--- a/scripts/test_sanitized_extension.sh
+++ b/scripts/test_sanitized_extension.sh
@@ -72,6 +72,10 @@ run_sql "mode must be 'overlap' or 'contain'" \
   "CREATE TABLE cgr_san(chrom VARCHAR,start BIGINT,stop BIGINT); INSERT INTO cgr_san VALUES ('chr1',0,1); SELECT duckhts_cgranges_from_query('cgr_san_idx','SELECT * FROM cgr_san','chrom','start','stop'); SELECT * FROM duckhts_cgranges_overlaps('cgr_san_idx','chr1',0,1,mode:='bad');"
 run_sql "read_bcf: failed to read or parse BCF/VCF record" \
   "SELECT count(*) FROM read_bcf('test/data/malformed_bad_pos.vcf',tidy_format:=true);"
+for format in bcf vcf.gz; do
+  run_sql "read_bcf: failed to reload index for parallel scan" \
+    "SET threads=4; SELECT * FROM bcf_index('test/data/parallel_empty_contigs.$format',index_path:='$tmp/reload.$format.index',threads:=1); PREPARE scan AS SELECT POS FROM read_bcf('test/data/parallel_empty_contigs.$format',index_path:='$tmp/reload.$format.index',decompression_threads:=0); COPY (SELECT 'broken index') TO '$tmp/reload.$format.index' (FORMAT CSV,HEADER FALSE); EXECUTE scan;"
+done
 run_sql "region list: empty item" \
   "SELECT count(*) FROM read_bam('test/data/range.bam',region:=',,');"
 run_sql "region list: invalid item" \

--- a/src/bcf_reader.c
+++ b/src/bcf_reader.c
@@ -1992,6 +1992,15 @@ static void bcf_read_local_init(duckdb_init_info info) {
         }
     }
 
+    /* Bind already chose one-owner-per-contig scanning. Without the worker's
+     * index, every contig would look empty; streaming fallback would duplicate
+     * the file across workers. Fail this plan instead. */
+    if (is_parallel && !local->idx && !local->tbx) {
+        duckdb_init_set_error(info, "read_bcf: failed to reload index for parallel scan");
+        destroy_init_data(local);
+        return;
+    }
+
     // Set up region query if user specified a region (non-parallel case)
     if (!is_parallel && bind->n_regions > 0) {
         // First check if we have an index

--- a/test/sql/bcf_scan.test
+++ b/test/sql/bcf_scan.test
@@ -1,0 +1,115 @@
+# name: test/sql/bcf_scan.test
+# description: Index-dependent BCF/VCF scans fail when a worker loses its index
+# group: [duckhts]
+
+require duckhts
+
+statement ok
+SET threads=4;
+
+# Only generated indexes are overwritten; original fixture indexes are untouched.
+query I
+SELECT success FROM bcf_index('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.bcf',
+  index_path := '__WORKING_DIRECTORY__/test_bcf_reload.csi', threads := 1);
+----
+1
+
+statement ok
+PREPARE bcf_reload AS SELECT POS FROM read_bcf('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.bcf',
+  index_path := '__WORKING_DIRECTORY__/test_bcf_reload.csi', decompression_threads := 0);
+
+statement ok
+PREPARE bcf_reload_count AS SELECT count(POS) FROM read_bcf('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.bcf',
+  index_path := '__WORKING_DIRECTORY__/test_bcf_reload.csi', decompression_threads := 0);
+
+query I
+SELECT count(*) FROM read_bcf('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.bcf',
+  index_path := '__WORKING_DIRECTORY__/test_bcf_reload.csi', decompression_threads := 0);
+----
+2
+
+statement ok
+COPY (SELECT 'broken index') TO '__WORKING_DIRECTORY__/test_bcf_reload.csi' (FORMAT CSV, HEADER FALSE);
+
+statement error
+EXECUTE bcf_reload;
+----
+read_bcf: failed to reload index for parallel scan
+
+statement error
+EXECUTE bcf_reload_count;
+----
+read_bcf: failed to reload index for parallel scan
+
+# A new bind with no usable index still selects ordinary sequential fallback.
+query I rowsort
+SELECT POS FROM read_bcf('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.bcf',
+  index_path := '__WORKING_DIRECTORY__/test_bcf_reload.csi', decompression_threads := 0);
+----
+10
+40
+
+query I
+SELECT success FROM bcf_index('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.bcf',
+  index_path := '__WORKING_DIRECTORY__/test_bcf_reload.csi', threads := 1);
+----
+1
+
+# Re-executing the same prepared query recovers after restoring the index.
+query I rowsort
+EXECUTE bcf_reload;
+----
+10
+40
+
+query I
+SELECT success FROM bcf_index('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.vcf.gz',
+  index_path := '__WORKING_DIRECTORY__/test_vcf_reload.tbi', threads := 1);
+----
+1
+
+statement ok
+PREPARE vcf_reload AS SELECT POS FROM read_bcf('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.vcf.gz',
+  index_path := '__WORKING_DIRECTORY__/test_vcf_reload.tbi', decompression_threads := 0);
+
+statement ok
+PREPARE vcf_reload_count AS SELECT count(POS) FROM read_bcf('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.vcf.gz',
+  index_path := '__WORKING_DIRECTORY__/test_vcf_reload.tbi', decompression_threads := 0);
+
+query I
+SELECT count(*) FROM read_bcf('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.vcf.gz',
+  index_path := '__WORKING_DIRECTORY__/test_vcf_reload.tbi', decompression_threads := 0);
+----
+2
+
+statement ok
+COPY (SELECT 'broken index') TO '__WORKING_DIRECTORY__/test_vcf_reload.tbi' (FORMAT CSV, HEADER FALSE);
+
+statement error
+EXECUTE vcf_reload;
+----
+read_bcf: failed to reload index for parallel scan
+
+statement error
+EXECUTE vcf_reload_count;
+----
+read_bcf: failed to reload index for parallel scan
+
+query I rowsort
+SELECT POS FROM read_bcf('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.vcf.gz',
+  index_path := '__WORKING_DIRECTORY__/test_vcf_reload.tbi', decompression_threads := 0);
+----
+10
+40
+
+query I
+SELECT success FROM bcf_index('__WORKING_DIRECTORY__/test/data/parallel_empty_contigs.vcf.gz',
+  index_path := '__WORKING_DIRECTORY__/test_vcf_reload.tbi', threads := 1);
+----
+1
+
+query I rowsort
+EXECUTE vcf_reload;
+----
+10
+40


### PR DESCRIPTION
## Summary

Closes https://github.com/RGenomicsETL/duckhts/issues/198.

`read_bcf` now errors when an automatic contig scan cannot reload its bind-time index in a worker. Previously a prepared query could silently lose every record after its index was removed or corrupted. Falling back independently in parallel workers would duplicate records, so this index-dependent plan must fail.

The change is one local-init guard, mirrored in the R package. Normal no-index-at-bind fallback, explicit sequential scans, region iteration, count planning, and worker-local handle ownership are unchanged.

Scope limitation confirmed during review: a different but structurally valid replacement index still loads successfully and can produce wrong results on both the pre-fix and candidate binaries. This PR does not establish input/index identity or snapshot semantics. That reproduced defect and its required local/remote, automatic/explicit, identical-rebuild and different-offset cases are tracked in https://github.com/RGenomicsETL/duckhts/issues/201; it remains part of the reader-fix backlog.

## Validation

- New SQL regression fails against the pre-fix binary because the prepared query unexpectedly succeeds with zero rows.
- BCF/CSI and VCF.gz/TBI private-index corruption/removal; 1/4 requested DuckDB threads; wide/tidy full-row comparisons; exact restored-index and same-connection recovery. Original fixture indexes are untouched.
- `make release -j2` and `make test_release`: passed, including all 40 SQL files and unchanged native property/fuzz gates.
- R bootstrap and `THREADS=4 make test`: 2,778 assertions passed, without new warnings.
- ASan and UBSan extension gates: passed, including prepared-query index failures.
- Native allocation-failure probes: 461 allocation failures and 48 BAM list failures; installed-R probes: 62 allocation failures and 48 BAM list failures. Recovery checks passed; no tracked leaks.
- Both changelogs updated; no public signature changes.

## Performance

Source: checked-in [`benchmarks/benchmark_bcf_scan_init.md`](benchmarks/benchmark_bcf_scan_init.md), rendered from R. Candidate source revision `f06064bade5bd6dadcd6dceffb92669155a6d913`, source tree `e906cdc916567d4c995a52f2bf7d14267c0f2e48`; paired baseline `536cf59425fe5be9aa4e2518feaadd226901146b`. The report commit changes no extension source.

Both committed fixtures contain 257 header contigs, 256 empty contigs, and two input records. BCF input is 1,351 bytes plus a 117-byte CSI; VCF.gz input is 372 bytes plus a 106-byte TBI. Every timed CTAS materializes two complete eight-column rows, verified exactly outside the timer. Nine timed calls after warm-up, fresh R process per build/format/thread setting, DuckDB R 1.5.3, HTSlib 1.24, CPU affinity 0,2,4,6, 1/4 requested DuckDB threads, zero HTSlib decompression workers per handle.

Median elapsed milliseconds, baseline → candidate:

| Format | DuckDB threads | Median ms |
| --- | ---: | ---: |
| BCF/CSI | 1 | 1.203 → 1.161 |
| BCF/CSI | 4 | 1.254 → 1.217 |
| VCF.gz/TBI | 1 | 0.952 → 0.902 |
| VCF.gz/TBI | 4 | 0.925 → 0.902 |

These are tiny-fixture setup/materialization timings, not evidence of a general speedup or no regression. Failure latency, remote I/O, RSS and large-cohort indexed throughput are not measured. The nearest larger report, [`benchmarks/benchmark_reader_allocations.md`](benchmarks/benchmark_reader_allocations.md), measures 4,048,342 GIAB HG002 records at source `05fcdfdfcb32eb94a987d946e65d377040644c1a`, one sequential handle, one DuckDB thread and zero decompression workers: candidate wide 14.592 s / tidy 14.797 s. It does not exercise the index-reload path and is not a comparable workload.

## Merge gates

Codex reviewed current head `6d6b5d2ad1ce7ef8640fd2fda152b930a8ff14a0` and reported no major issues after the scope clarification: https://github.com/RGenomicsETL/duckhts/pull/199#issuecomment-5555796845. All 21 CI checks passed on that head before merge, including the six downstream distribution builds. The valid-replacement finding remains open in issue 201, not claimed fixed here. This fixes the reproduced index-load-failure defect; it does not close the broader BCF consolidation or genotype-reader work.
