### PR TITLE
Compare haplotype edit mechanics with executable Haplosaurus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 	duckvep-so-spec duckvep-so-spec-check \
 	test-duckvep-witnesses test-duckvep-differential \
 	test-duckvep-gvcf-differential \
+	test-duckvep-haplotype-mechanics \
 	test-duckvep-state-exploration \
 	test-duckvep-release-vcf \
 	duckvep-corpus-differential duckvep-statistical-report \
@@ -568,6 +569,12 @@ test-duckvep-differential: release
 	VEP_PREFIX=$(VEP_PREFIX) Rscript test/duckvep/conformance/corpus_differential.R \
 		--extension build/release/duckhts.duckdb_extension \
 		--sample-per-shape 0 --hgvs
+
+# Independent Haplosaurus oracle for the existing native edit-set mechanics.
+# No DuckDB build or public phased-execution claim is involved.
+test-duckvep-haplotype-mechanics:
+	VEP_PREFIX=$(VEP_PREFIX) Rscript test/duckvep/conformance/haplotype_differential.R \
+		$(DUCKVEP_HAPLOTYPE_ARGS)
 
 # VEP receives one single-ALT record for each expanded input allele. This pins
 # both ALT orders in mixed gVCF records without asking either engine to infer

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # DuckHTS Extension News
 
 # duckhts 1.5.1.9000
+- add a seeded executable Haplosaurus differential for native multi-edit CDS
+  mutation and translation, comparing complete sequences, frame flags and
+  contributor/sample counts. This developer gate does not certify the pending
+  public phased executor, compound SO/HGVS or arbitrary-ploidy compatibility
+
 - preserve literal colon-bearing contig names in indexed BCF/VCF full scans;
   internal contig tasks no longer parse dictionary names as region expressions.
   Share file/header/iterator ownership and decode diagnostics in a host-neutral

--- a/test/duckvep/conformance/README.md
+++ b/test/duckvep/conformance/README.md
@@ -495,3 +495,33 @@ The corpus runner currently compares independent alleles. The pure C tests cover
 edit grouping, same-codon interactions, open frameshifts, and restored frameshifts; a VEP
 Haplosaurus differential belongs with the public phased input surface rather than being
 faked in this runner.
+
+`make test-duckvep-haplotype-mechanics` runs the narrower executable prerequisite:
+the existing pure-C edit application/translation helpers against the pinned Haplosaurus
+parser, genomic-to-CDS mapper and transcript container. It generates two-exon transcripts
+on both strands, ordinary genomic VCF records, cis/trans diploid carriers and shared
+haplotypes. Same-codon substitutions, open/restored frameshifts, in-frame edits and seeded
+random edit sets are compared by complete alternate CDS/protein sequence, frame flags,
+every CDS contributor, per-sample counts and total carrier counts. For a larger campaign:
+
+```sh
+make test-duckvep-haplotype-mechanics DUCKVEP_HAPLOTYPE_ARGS="--cases 1000 --seed 173"
+```
+
+The R driver supplies known original-CDS coordinates to a test-only `.C` bridge;
+Haplosaurus independently parses and projects the same genomic alleles. The Perl observer
+changes only serialization. Clean exact-commit VEP/Variation mirrors and the existing
+exact-package environment lock are required. Generated inputs, both engines' complete
+observations, mismatch rows, counts and byte receipts remain in a unique directory under
+`results/`, including after a failed comparison. These diagnostic receipts do not update
+release conformance histories or the `not_implemented` phased transition.
+Seven deliberate corruptions exercise each comparison field; their rejection counts
+are reported separately from the real engine comparisons.
+
+This is **not** a public phased-executor certificate: it does not test DuckDB carrier
+streaming, strict phase/PS grouping, sparse-prefix ownership, compound SO/HGVS, structural
+composition or arbitrary ploidy. Haplosaurus exposes sequence differences and frame
+flags, not a compound SO/HGVS oracle. Its offline container also defaults to two lanes
+without inferring VCF ploidy; that behavior must not silently define DuckVEP's ploidy
+contract. The existing independent-event and pure-C property campaigns remain separate
+and unchanged.

--- a/test/duckvep/conformance/haplotype_differential.R
+++ b/test/duckvep/conformance/haplotype_differential.R
@@ -1,0 +1,645 @@
+#!/usr/bin/env Rscript
+# Executable Haplosaurus comparison for the existing edit-set mechanics.
+# The declared model supplies CDS coordinates to C; Haplosaurus independently
+# parses the VCF and projects it through GFF. This does not certify SQL carrier
+# grouping, strict phase, compound SO/HGVS, or arbitrary-ploidy compatibility.
+
+main <- function() {
+  opt <- optparse::parse_args(optparse::OptionParser(
+    option_list = list(
+      optparse::make_option("--cases", type = "integer", default = 128L),
+      optparse::make_option("--seed", type = "integer", default = 173L),
+      optparse::make_option(
+        "--vep-prefix",
+        dest = "vep_prefix",
+        default = Sys.getenv(
+          "VEP_PREFIX",
+          "/root/miniconda3/envs/vep"
+        )
+      ),
+      optparse::make_option(
+        "--vep-git",
+        dest = "vep_git",
+        default = ".sync/ensembl-vep"
+      ),
+      optparse::make_option(
+        "--variation-git",
+        dest = "variation_git",
+        default = ".sync/ensembl-variation"
+      )
+    )
+  ))
+  stopifnot(opt$cases >= 10L, opt$cases <= 100000L, !is.na(opt$seed))
+  root <- normalizePath(system2(
+    "git",
+    c("rev-parse", "--show-toplevel"),
+    stdout = TRUE
+  ))
+  source(file.path(root, "scripts/duckvep_evidence.R"), local = TRUE)
+  results <- file.path(root, "test/duckvep/conformance/results")
+  dir.create(results, showWarnings = FALSE)
+  out <- tempfile(paste0("haplotype_seed", opt$seed, "_"), tmpdir = results)
+  dir.create(out)
+  message("Artifacts: ", out)
+
+  # Fail closed on a different oracle or a modified source checkout. Environment
+  # matching uses the same exact-package authority as independent-event campaigns.
+  revisions <- c(
+    vep = "57ea5c52340acc1f156267f810ad162e26597082",
+    variation = "2fb834b987ede3824e200197a838ce11e91aeb4b"
+  )
+  mirrors <- c(
+    vep = normalizePath(opt$vep_git, mustWork = TRUE),
+    variation = normalizePath(opt$variation_git, mustWork = TRUE)
+  )
+  for (name in names(mirrors)) {
+    revision <- system2(
+      "git",
+      c("-C", shQuote(mirrors[[name]]), "rev-parse", "HEAD"),
+      stdout = TRUE
+    )
+    dirty <- system2(
+      "git",
+      c("-C", shQuote(mirrors[[name]]), "status", "--porcelain"),
+      stdout = TRUE
+    )
+    stopifnot(identical(revision, revisions[[name]]), !length(dirty))
+  }
+  prefix <- normalizePath(opt$vep_prefix, mustWork = TRUE)
+  conda <- function(...) {
+    do.call(
+      blit::conda,
+      c(
+        as.list(duckvep_blit_quote(c(...))),
+        list(conda = duckvep_blit_quote("micromamba"))
+      )
+    )
+  }
+  environment_path <- file.path(out, "environment.txt")
+  stopifnot(
+    blit::cmd_run(
+      conda("list", "-p", prefix, "--explicit"),
+      stdout = environment_path,
+      stderr = "2>&1",
+      verbose = FALSE
+    ) ==
+      0L
+  )
+  lock <- file.path(
+    root,
+    "test/duckvep/upstream/receipts/vep116_2026-07-22.conda-explicit.txt"
+  )
+  stopifnot(identical(
+    duckvep_evidence_explicit_packages(readLines(environment_path)),
+    duckvep_evidence_explicit_packages(readLines(lock))
+  ))
+
+  # A small native test bridge, not another production annotation implementation.
+  shared <- file.path(out, paste0("haplotype_probe", .Platform$dynlib.ext))
+  sources <- file.path(
+    root,
+    c(
+      "test/duckvep/conformance/haplotype_probe.c",
+      "src/duckvep/kernel/src/duckvep_haplotype.c",
+      "src/duckvep/kernel/src/duckvep_codon.c"
+    )
+  )
+  compiler <- Sys.getenv("CC", "cc")
+  stopifnot(
+    system2(
+      compiler,
+      c(
+        "-std=c99",
+        "-O1",
+        "-g",
+        "-Wall",
+        "-Wextra",
+        "-fPIC",
+        "-shared",
+        "-I",
+        shQuote(file.path(root, "src/duckvep/kernel/src")),
+        shQuote(sources),
+        "-o",
+        shQuote(shared)
+      ),
+      stdout = file.path(out, "compiler.log"),
+      stderr = file.path(out, "compiler.log")
+    ) ==
+      0L
+  )
+  dll <- dyn.load(shared)
+  on.exit(dyn.unload(shared), add = TRUE)
+  symbol <- getNativeSymbolInfo("duckhts_test_haplotype", PACKAGE = dll)
+  reverse_complement <- function(x) {
+    paste(rev(strsplit(chartr("ACGT", "TGCA", x), "")[[1L]]), collapse = "")
+  }
+  dna <- function(n) {
+    paste(sample(c("A", "C", "G", "T"), n, replace = TRUE), collapse = "")
+  }
+  codons <- apply(
+    expand.grid(rep(list(c("A", "C", "G", "T")), 3L)),
+    1L,
+    paste,
+    collapse = ""
+  )
+  codons <- setdiff(codons, c("TAA", "TAG", "TGA"))
+  shapes <- c(
+    "same_codon",
+    "restored_frame",
+    "open_frame",
+    "in_frame",
+    "random_set"
+  )
+  set.seed(opt$seed)
+  cases <- vector("list", opt$cases)
+  fasta <- gff <- vcf <- vector("list", opt$cases)
+  for (i in seq_len(opt$cases)) {
+    chrom <- sprintf("chrH%06d", i)
+    transcript <- sprintf("DHT%06d", i)
+    strand <- if (i %% 2L) 1L else -1L
+    shape <- shapes[(i - 1L) %% length(shapes) + 1L]
+    cds <- paste0(
+      "ATG",
+      paste(sample(codons, 58L, replace = TRUE), collapse = ""),
+      "TAA"
+    )
+    genome_cds <- if (strand == 1L) cds else reverse_complement(cds)
+    intron <- if (strand == 1L) {
+      paste0("GT", strrep("A", 26L), "AG")
+    } else {
+      paste0("CT", strrep("T", 26L), "AC")
+    }
+    genome <- paste0(
+      strrep("A", 10L),
+      substr(genome_cds, 1L, 90L),
+      intron,
+      substr(genome_cds, 91L, 180L),
+      strrep("A", 10L)
+    )
+    stopifnot(nchar(cds) == 180L, nchar(genome) == 230L)
+    fasta[[i]] <- c(paste0(">", chrom), genome)
+    features <- data.frame(
+      feature = c("gene", "mRNA", "exon", "CDS", "exon", "CDS"),
+      start = c(11L, 11L, 11L, 11L, 131L, 131L),
+      end = c(220L, 220L, 100L, 100L, 220L, 220L),
+      phase = c(".", ".", ".", "0", ".", "0"),
+      attributes = c(
+        paste0("ID=gene:", transcript, ";biotype=protein_coding"),
+        paste0(
+          "ID=transcript:",
+          transcript,
+          ";Parent=gene:",
+          transcript,
+          ";biotype=protein_coding"
+        ),
+        paste0("ID=exon:", transcript, "a;Parent=transcript:", transcript),
+        paste0("Parent=transcript:", transcript),
+        paste0("ID=exon:", transcript, "b;Parent=transcript:", transcript),
+        paste0("Parent=transcript:", transcript)
+      )
+    )
+    gff[[i]] <- apply(features, 1L, function(row) {
+      paste(
+        c(
+          chrom,
+          "duckvep",
+          row["feature"],
+          trimws(row["start"]),
+          trimws(row["end"]),
+          ".",
+          if (strand == 1L) "+" else "-",
+          row["phase"],
+          row["attributes"]
+        ),
+        collapse = "\t"
+      )
+    })
+    edits <- switch(
+      shape,
+      same_codon = data.frame(start = c(4L, 5L), ref_len = 1L, alt_len = 1L),
+      restored_frame = data.frame(
+        start = c(10L, 40L),
+        ref_len = c(0L, 1L),
+        alt_len = c(1L, 0L)
+      ),
+      open_frame = data.frame(
+        start = c(10L, 40L),
+        ref_len = c(0L, 1L),
+        alt_len = c(2L, 1L)
+      ),
+      in_frame = data.frame(
+        start = c(10L, 40L),
+        ref_len = c(0L, 3L),
+        alt_len = c(3L, 0L)
+      ),
+      random_set = {
+        starts <- sort(sample(
+          c(seq(4L, 82L, 6L), seq(94L, 172L, 6L)),
+          sample(2:10, 1L)
+        ))
+        data.frame(
+          start = starts,
+          ref_len = sample(0:3, length(starts), TRUE),
+          alt_len = sample(0:4, length(starts), TRUE)
+        )
+      }
+    )
+    edits$ref <- substring(cds, edits$start, edits$start + edits$ref_len - 1L)
+    edits$ref[edits$ref_len == 0L] <- ""
+    edits$alt <- vapply(edits$alt_len, dna, "")
+    for (j in seq_len(nrow(edits))) {
+      while (edits$ref[j] == edits$alt[j]) {
+        if (edits$alt_len[j] == 0L) {
+          edits$alt_len[j] <- 1L
+        }
+        edits$alt[j] <- dna(edits$alt_len[j])
+      }
+    }
+    # C sees unanchored edits in original-CDS coordinates, with genomic-strand
+    # alleles. Haplosaurus sees ordinary left-anchored genomic VCF records.
+    if (strand == -1L) {
+      edits$ref <- vapply(edits$ref, reverse_complement, "")
+      edits$alt <- vapply(edits$alt, reverse_complement, "")
+    }
+    edits$id <- paste0(transcript, "_e", seq_len(nrow(edits)))
+    genomic_position <- function(p) {
+      if (strand == 1L) {
+        ifelse(p <= 90L, p + 10L, p + 40L)
+      } else {
+        ifelse(p <= 90L, 221L - p, 191L - p)
+      }
+    }
+    variants <- vector("list", nrow(edits))
+    for (j in seq_len(nrow(edits))) {
+      edit <- edits[j, ]
+      pos <- if (strand == 1L || edit$ref_len == 0L) {
+        genomic_position(edit$start)
+      } else {
+        genomic_position(edit$start + edit$ref_len - 1L)
+      }
+      ref <- edit$ref
+      alt <- edit$alt
+      if (edit$ref_len == 0L || edit$alt_len == 0L) {
+        pos <- pos - as.integer(edit$ref_len != 0L || strand == 1L)
+        anchor <- substring(genome, pos, pos)
+        ref <- paste0(anchor, ref)
+        alt <- paste0(anchor, alt)
+      }
+      stopifnot(substring(genome, pos, pos + nchar(ref) - 1L) == ref)
+      variants[[j]] <- data.frame(
+        pos = pos,
+        row = paste(
+          c(
+            chrom,
+            pos,
+            edit$id,
+            ref,
+            alt,
+            ".",
+            "PASS",
+            ".",
+            "GT:PS",
+            "1|0:10",
+            if (j %% 2L) "1|0:10" else "0|1:10",
+            "1|0:10"
+          ),
+          collapse = "\t"
+        )
+      )
+    }
+    variants <- do.call(rbind, variants)
+    vcf[[i]] <- variants$row[order(variants$pos)]
+    cases[[i]] <- list(
+      transcript = transcript,
+      shape = shape,
+      strand = strand,
+      cds = cds,
+      edits = edits
+    )
+  }
+  fasta <- unlist(fasta, use.names = FALSE)
+  gff <- unlist(gff, use.names = FALSE)
+  vcf <- unlist(vcf, use.names = FALSE)
+  writeLines(fasta, file.path(out, "reference.fa"))
+  writeLines(c("##gff-version 3", gff), file.path(out, "model.gff3"))
+  writeLines(
+    c(
+      "##fileformat=VCFv4.2",
+      sprintf("##contig=<ID=chrH%06d,length=230>", seq_len(opt$cases)),
+      "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+      "##FORMAT=<ID=PS,Number=1,Type=Integer,Description=\"Phase set\">",
+      "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tcis\ttrans\tshared",
+      vcf
+    ),
+    file.path(out, "carriers.vcf")
+  )
+  saveRDS(list(seed = opt$seed, cases = cases), file.path(out, "inputs.rds"))
+  stopifnot(
+    system2("samtools", c("faidx", shQuote(file.path(out, "reference.fa")))) ==
+      0L,
+    system2("bgzip", shQuote(file.path(out, "model.gff3"))) == 0L,
+    system2(
+      "tabix",
+      c("-p", "gff", shQuote(file.path(out, "model.gff3.gz")))
+    ) ==
+      0L
+  )
+  perl_lib <- paste(
+    c(
+      file.path(mirrors, "modules"),
+      file.path(prefix, "share/ensembl-vep-116.0-0")
+    ),
+    collapse = ":"
+  )
+  run <- conda(
+    "run",
+    "--clean-env",
+    "--env",
+    paste0("PERL5LIB=", perl_lib),
+    "-p",
+    prefix,
+    "perl",
+    file.path(root, "test/duckvep/conformance/haplotype_oracle.pl"),
+    file.path(out, "carriers.vcf"),
+    file.path(out, "reference.fa"),
+    file.path(out, "model.gff3.gz")
+  )
+  stopifnot(
+    blit::cmd_run(
+      run,
+      stdout = file.path(out, "oracle.jsonl"),
+      stderr = file.path(out, "oracle.log"),
+      stdin = NULL,
+      verbose = FALSE
+    ) ==
+      0L
+  )
+  observed <- lapply(
+    readLines(file.path(out, "oracle.jsonl")),
+    jsonlite::fromJSON,
+    simplifyVector = FALSE
+  )
+  ids <- vapply(observed, `[[`, "", "transcript")
+  stopifnot(
+    !anyDuplicated(ids),
+    setequal(ids, vapply(cases, `[[`, "", "transcript"))
+  )
+  names(observed) <- ids
+
+  apply_edits <- function(case, selected) {
+    edits <- case$edits[selected, , drop = FALSE]
+    edits <- edits[order(edits$start, decreasing = TRUE), , drop = FALSE]
+    capacity <- nchar(case$cds) + sum(nchar(edits$alt)) + 1L
+    answer <- .C(
+      symbol,
+      charToRaw(case$cds),
+      as.integer(nchar(case$cds)),
+      case$strand,
+      as.integer(edits$start),
+      edits$ref,
+      edits$alt,
+      as.integer(nrow(edits)),
+      cds = raw(capacity),
+      as.integer(capacity),
+      protein = raw(capacity),
+      as.integer(capacity),
+      status = integer(1L),
+      cds_length = integer(1L),
+      protein_length = integer(1L),
+      flags = integer(1L)
+    )
+    stopifnot(answer$status == 0L)
+    list(
+      cds = rawToChar(answer$cds[seq_len(answer$cds_length)]),
+      protein = rawToChar(answer$protein[seq_len(answer$protein_length)]),
+      flags = sort(c("indel", "frameshift", "resolved_frameshift")[
+        bitwAnd(answer$flags, c(1L, 2L, 4L)) != 0L
+      ]),
+      contributors = sort(edits$id)
+    )
+  }
+  compare_haplotypes <- function(expected, oracle) {
+    groups <- split(expected, vapply(expected, `[[`, "", "cds"))
+    checks <- logical()
+    compare <- function(condition, field) {
+      checks <<- c(checks, setNames(isTRUE(condition), field))
+    }
+    compare(oracle$total_haplotype_count == 6L, "total_haplotype_count")
+    compare(
+      setequal(names(groups), vapply(oracle$haplotypes, `[[`, "", "cds")),
+      "complete_CDS_set"
+    )
+    for (haplotype in oracle$haplotypes) {
+      carriers <- groups[[haplotype$cds]]
+      if (is.null(carriers)) {
+        next
+      }
+      compare(
+        all(vapply(
+          carriers,
+          function(x) identical(x$protein, haplotype$protein),
+          TRUE
+        )),
+        "complete_protein"
+      )
+      compare(
+        all(vapply(
+          carriers,
+          function(x) {
+            identical(x$flags, sort(as.character(unlist(haplotype$flags))))
+          },
+          TRUE
+        )),
+        "frame_flags"
+      )
+      compare(
+        setequal(
+          unique(unlist(lapply(carriers, `[[`, "contributors"))),
+          unlist(haplotype$contributors)
+        ),
+        "complete_contributors"
+      )
+      counts <- table(vapply(carriers, `[[`, "", "sample"))
+      actual_counts <- unlist(haplotype$samples)
+      compare(
+        identical(sort(names(counts)), sort(names(actual_counts))) &&
+          identical(
+            as.integer(counts[sort(names(counts))]),
+            as.integer(actual_counts[sort(names(actual_counts))])
+          ),
+        "sample_counts"
+      )
+      compare(haplotype$count == length(carriers), "carrier_count")
+    }
+    checks
+  }
+  failures <- list()
+  comparisons <- 0L
+  native <- vector("list", length(cases))
+  names(native) <- vapply(cases, `[[`, "", "transcript")
+  for (case in cases) {
+    expected <- list()
+    for (sample in c("cis", "trans", "shared")) {
+      for (lane in 1:2) {
+        selected <- if (sample == "trans") {
+          seq_len(nrow(case$edits)) %% 2L == (lane %% 2L)
+        } else {
+          rep(lane == 1L, nrow(case$edits))
+        }
+        haplotype <- apply_edits(case, selected)
+        haplotype$sample <- sample
+        expected[[length(expected) + 1L]] <- haplotype
+      }
+    }
+    native[[case$transcript]] <- expected
+    checks <- compare_haplotypes(expected, observed[[case$transcript]])
+    comparisons <- comparisons + length(checks)
+    if (any(!checks)) {
+      failures[[length(failures) + 1L]] <- data.frame(
+        transcript = case$transcript,
+        shape = case$shape,
+        strand = case$strand,
+        field = names(checks)[!checks]
+      )
+    }
+  }
+  failures <- if (length(failures)) {
+    do.call(rbind, failures)
+  } else {
+    data.frame(
+      transcript = character(),
+      shape = character(),
+      strand = integer(),
+      field = character()
+    )
+  }
+  saveRDS(native, file.path(out, "native.rds"))
+  write.csv(failures, file.path(out, "failures.csv"), row.names = FALSE)
+  # Exercise every comparison axis with a deliberate corruption. These seven
+  # verifier controls are separate from the engine-comparison denominators.
+  controls <- data.frame(
+    field = c(
+      "total_haplotype_count",
+      "complete_CDS_set",
+      "complete_protein",
+      "frame_flags",
+      "complete_contributors",
+      "sample_counts",
+      "carrier_count"
+    ),
+    rejected = FALSE
+  )
+  first <- observed[[cases[[1L]]$transcript]]
+  if (all(compare_haplotypes(native[[1L]], first))) {
+    for (i in seq_len(nrow(controls))) {
+      mutant <- first
+      switch(
+        controls$field[i],
+        total_haplotype_count = {
+          mutant$total_haplotype_count <- first$total_haplotype_count + 1L
+        },
+        complete_CDS_set = {
+          mutant$haplotypes[[1L]]$cds <- "N"
+        },
+        complete_protein = {
+          mutant$haplotypes[[1L]]$protein <- "WRONG"
+        },
+        frame_flags = {
+          mutant$haplotypes[[1L]]$flags <- list("WRONG")
+        },
+        complete_contributors = {
+          mutant$haplotypes[[1L]]$contributors <- list("WRONG")
+        },
+        sample_counts = {
+          mutant$haplotypes[[1L]]$samples <- list(WRONG = 1L)
+        },
+        carrier_count = {
+          mutant$haplotypes[[1L]]$count <- first$haplotypes[[1L]]$count + 1L
+        }
+      )
+      checks <- compare_haplotypes(native[[1L]], mutant)
+      controls$rejected[i] <- any(!checks[names(checks) == controls$field[i]])
+    }
+  }
+  write.csv(
+    controls,
+    file.path(out, "verifier_controls.csv"),
+    row.names = FALSE
+  )
+  summary <- data.frame(
+    seed = opt$seed,
+    transcripts = length(cases),
+    input_records = length(vcf),
+    input_allele_slots = 6L * length(vcf),
+    haplotype_lanes = 6L * length(cases),
+    comparisons = comparisons,
+    failures = nrow(failures),
+    verifier_controls_rejected = sum(controls$rejected)
+  )
+  write.csv(summary, file.path(out, "summary.csv"), row.names = FALSE)
+  identities <- c(
+    sources,
+    file.path(root, "test/duckvep/conformance/haplotype_differential.R"),
+    file.path(root, "test/duckvep/conformance/haplotype_oracle.pl"),
+    file.path(
+      root,
+      c(
+        "scripts/duckvep_evidence.R",
+        "src/duckvep/kernel/src/duckvep_haplotype.h",
+        "src/duckvep/kernel/src/duckvep_codon.h",
+        "src/duckvep/kernel/src/duckvep_dna.h"
+      )
+    ),
+    lock,
+    file.path(
+      out,
+      c(
+        "reference.fa",
+        "reference.fa.fai",
+        "model.gff3.gz",
+        "model.gff3.gz.tbi",
+        "carriers.vcf",
+        "inputs.rds",
+        "native.rds",
+        "oracle.jsonl",
+        "summary.csv",
+        "failures.csv",
+        "verifier_controls.csv",
+        "environment.txt"
+      )
+    ),
+    shared
+  )
+  hashes <- vapply(identities, duckvep_evidence_sha256, "")
+  jsonlite::write_json(
+    list(
+      scope = "diploid_edit_set_mechanics_not_public_phased_execution",
+      source_revision = system2("git", c("rev-parse", "HEAD"), stdout = TRUE),
+      dirty_worktree = length(system2(
+        "git",
+        c("status", "--porcelain"),
+        stdout = TRUE
+      )) !=
+        0L,
+      oracle_revisions = as.list(revisions),
+      seed = opt$seed,
+      compiler = system2(compiler, "--version", stdout = TRUE),
+      sha256 = as.list(hashes)
+    ),
+    file.path(out, "receipt.json"),
+    auto_unbox = TRUE,
+    pretty = TRUE
+  )
+  print(summary, row.names = FALSE)
+  if (!all(controls$rejected)) {
+    stop("Haplosaurus comparison controls failed; inspect ", out, call. = FALSE)
+  }
+  if (nrow(failures)) {
+    stop(
+      "Haplosaurus mechanics differential failed; inspect ",
+      out,
+      call. = FALSE
+    )
+  }
+}
+main()

--- a/test/duckvep/conformance/haplotype_oracle.pl
+++ b/test/duckvep/conformance/haplotype_oracle.pl
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Bio::EnsEMBL::VEP::Haplo::Runner;
+use JSON;
+use File::Basename qw(dirname);
+
+# Observe the real release-116 parser, mapper and container. Only output is
+# replaced: upstream's tabular output omits the complete sequences, and its
+# JSON prefetch does not include CDS frameshift flags. No genotype, projection,
+# mutation, translation or phase behavior is overridden here.
+{
+    package DuckHTS::HaploObserver;
+    use parent 'Bio::EnsEMBL::VEP::Haplo::Runner';
+
+    sub dump_TranscriptHaplotypeContainer {
+        my ($self, $container) = @_;
+        my @haplotypes;
+        foreach my $cds (@{$container->get_all_CDSHaplotypes}) {
+            my $protein = $cds->get_ProteinHaplotype;
+            push @haplotypes, {
+                cds => $cds->seq,
+                protein => $protein->seq,
+                flags => [sort @{$cds->get_all_flags}],
+                contributors => [sort map {$_->variation_name}
+                                      @{$cds->get_all_VariationFeatures}],
+                samples => $cds->get_all_sample_counts,
+                count => $cds->count,
+            };
+        }
+        print JSON->new->canonical->encode({
+            transcript => $container->transcript->stable_id,
+            total_haplotype_count => $container->total_haplotype_count,
+            haplotypes => [sort {$a->{cds} cmp $b->{cds}} @haplotypes],
+        }), "\n";
+        $self->{_output_lines_count}++;
+    }
+}
+
+@ARGV == 3 or die "usage: haplotype_oracle.pl input.vcf reference.fa model.gff3.gz\n";
+my ($vcf, $fasta, $gff) = @ARGV;
+my $runner = DuckHTS::HaploObserver->new({
+    input_file => $vcf,
+    fasta => $fasta,
+    gff => $gff,
+    dir => dirname($vcf),
+    output_file => 'STDOUT',
+    warning_file => $vcf . '.warnings',
+    database => 0,
+    no_stats => 1,
+});
+$runner->run;

--- a/test/duckvep/conformance/haplotype_probe.c
+++ b/test/duckvep/conformance/haplotype_probe.c
@@ -1,0 +1,53 @@
+/* Test-only R .C bridge to the unmodified, host-neutral mutation kernel.
+ * R owns every input/output buffer; this bridge owns only edit descriptors.
+ * This is not a SQL adapter or an implementation of carrier stream grouping. */
+#include "duckvep_haplotype.h"
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+void duckhts_test_haplotype(
+    uint8_t *reference, int *reference_length, int *strand,
+    int *starts, char **refs, char **alts, int *edit_count,
+    uint8_t *cds, int *cds_capacity, uint8_t *protein, int *protein_capacity,
+    int *status, int *cds_length, int *protein_length, int *flags) {
+    duckvep_haplotype_edit_t *edits = NULL;
+    duckvep_haplotype_result_t applied, translated;
+    size_t cds_len = 0, protein_len = 0;
+    *status = DUCKVEP_HAPLOTYPE_INVALID_ARG;
+    *cds_length = *protein_length = *flags = 0;
+    if (*reference_length < 0 || *edit_count < 0 || *edit_count > 1000000 ||
+        *cds_capacity < 1 || *protein_capacity < 1 ||
+        (*strand != -1 && *strand != 1)) return;
+    if (*edit_count) {
+        edits = calloc((size_t)*edit_count, sizeof(*edits));
+        if (!edits) return;
+    }
+    for (int i = 0; i < *edit_count; i++) {
+        size_t ref_len = strlen(refs[i]), alt_len = strlen(alts[i]);
+        if (starts[i] < 1 || ref_len > UINT32_MAX || alt_len > UINT32_MAX) goto cleanup;
+        edits[i].cds_start = (uint32_t)starts[i];
+        edits[i].ref_len = (uint32_t)ref_len;
+        edits[i].alt_len = (uint32_t)alt_len;
+        edits[i].ref = (const uint8_t *)refs[i];
+        edits[i].alt = (const uint8_t *)alts[i];
+        edits[i].variant_strand = 1;
+    }
+    *status = duckvep_haplotype_apply_cds_edits(reference, (size_t)*reference_length,
+        edits, (size_t)*edit_count, (int8_t)*strand, cds, (size_t)*cds_capacity,
+        &cds_len, &applied);
+    if (*status != DUCKVEP_HAPLOTYPE_OK) goto cleanup;
+    *status = duckvep_haplotype_translate_cds(cds, cds_len,
+        DUCKVEP_CODON_TABLE_STANDARD, protein, (size_t)*protein_capacity,
+        &protein_len, &translated);
+    if (*status != DUCKVEP_HAPLOTYPE_OK) goto cleanup;
+    if (cds_len > INT_MAX || protein_len > INT_MAX) {
+        *status = DUCKVEP_HAPLOTYPE_OUT_OF_RANGE;
+        goto cleanup;
+    }
+    *cds_length = (int)cds_len;
+    *protein_length = (int)protein_len;
+    *flags = (int)(applied.flags | translated.flags);
+cleanup:
+    free(edits);
+}


### PR DESCRIPTION
## Summary

Add the executable sequence-mechanics prerequisite for https://github.com/RGenomicsETL/duckhts/issues/92, which precedes https://github.com/RGenomicsETL/duckhts/issues/160. Neither issue is closed by this PR.

- Run the pinned VEP 116 Haplosaurus parser, genomic-to-CDS mapper and transcript container on generated two-exon models and ordinary VCF records. The Perl observer replaces serialization only; it does not replace biological methods or manufacture expected sequences.
- Compare complete alternate CDS and protein sequences, open/restored-frame and indel flags, all CDS contributors, per-sample counts and total carrier counts against the existing C edit-set application/translation functions through a test-only R `.C` bridge.
- Generate both strands, same-codon cis/trans substitutions, open/restored frameshifts, in-frame edits, random edit sets and repeated carrier paths. Keep exact generated inputs and both engines' observations after failures.
- Require clean exact-commit VEP/Variation source mirrors and the existing exact-package environment lock. Diagnostic receipts bind sources, headers, native test binary, inputs, outputs, compiler and worktree state. They do not update release conformance histories or relabel the phased state-machine transition.
- Reject deliberate corruption on each of the seven comparison axes, separately from engine-comparison denominators. Existing fixed/property/fuzz seeds, trial counts and independent-event oracles are unchanged.

This is deliberately a **mechanics differential**, not a public phased-executor implementation. It does not establish SQL carrier streaming, strict phase/PS behavior, sparse prefix ownership, compound SO/HGVS, structural composition or arbitrary-ploidy compatibility. C is given the declared original-CDS coordinates; only Haplosaurus performs genomic projection in this test. Its full protein sequence is compared, not its independently attributed protein contributor list.

The executable audit found that offline Haplosaurus defaults to two lanes: a triploid third ALT slot is dropped and a haploid missing second slot can become a deletion. That behavior must not silently choose DuckVEP's ploidy contract. This PR neither copies that bug into production nor claims polyploid conformance. Haplosaurus also does not directly supply compound SO terms or standard compound HGVS; those still need their own explicit validation contract.

## Validation

At `4836c1706adca3b6f731a3884e225d0c5ede2aca`, both native differentials completed with clean-worktree byte receipts:

| Seed | Transcripts | VCF records | Input allele slots | Haplotype lanes | Field comparisons | Mismatches | Corruptions rejected |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 173 | 1,000 | 2,764 | 16,584 | 6,000 | 22,000 | 0 | 7 |
| 20260906 | 1,000 | 2,802 | 16,812 | 6,000 | 22,000 | 0 | 7 |

Reproduce with `make test-duckvep-haplotype-mechanics DUCKVEP_HAPLOTYPE_ARGS='--cases 1000 --seed 173'` and the second seed. The target needs the pinned local mirrors and locked VEP environment; it does not download data or build DuckDB.

- Full `make test_release` passed, including all 40 SQL files and existing property, reader allocation-failure, SIMD, liftover and native scanner tests.
- Fresh full native property campaign: `DUCKVEP_PROP_TRIALS=100000 DUCKVEP_PROP_SEED=20260906 make test-duckvep-kernel`; all 215 tests and 212,151 assertions passed, no skipped tests.
- R driver formatted with `air`; `git diff --check` passed.
- No production C, SQL API, R package files, build manifest or generated catalog changed. Root NEWS records the developer gate; R NEWS is intentionally unchanged because there is no package-facing change. No new workflow or branch.

## Performance

No checked-in benchmark exercises this new developer-only mechanics differential. No production hot path changes in this PR. The nearest rendered baseline is [benchmarks/duckvep_throughput.md](https://github.com/RGenomicsETL/duckhts/blob/4836c1706adca3b6f731a3884e225d0c5ede2aca/benchmarks/duckvep_throughput.md), source revision `0eb1b440123871b0ee6e54bb2f99c61c50a264a5`: the Ensembl-116 GRCh38 full-literal GIAB public relation workload, **4,095,611 input alleles → 47,835,851 annotation rows**, four DuckDB threads, affinity `2,4,6,8`, five passes. Compact median **1.300 s**; rich median **2.740 s**. Those are independent-event measurements, not haplotype throughput, and are not a before/after comparison for this PR.

Missing measurement: end-to-end public phased execution, both already ordered and sort-included, with active carrier states, unique prefixes/completed haplotypes, translated bases, output rows and memory high-water mark. That remains required by issue 92. No speedup, no-regression, bounded-memory or fastest-reader claim is made here.

## Merge gates

Require a clean Codex review of the current head and all current-head CI checks before merge. No issue completion is inferred from this prerequisite passing.
