### PR TITLE
Add native model-scoped carrier paths for DuckVEP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,8 @@ DUCKVEP_KERNEL_SOURCES = \
 	src/duckvep/kernel/src/duckvep_hgvs.c \
 	src/duckvep/kernel/src/duckvep_codon.c \
 	src/duckvep/kernel/src/duckvep_coding.c \
-	src/duckvep/kernel/src/duckvep_haplotype.c
+	src/duckvep/kernel/src/duckvep_haplotype.c \
+	src/duckvep/kernel/src/duckvep_carriers.c
 DUCKVEP_PROPERTY_DRIVER = test/duckvep/property/duckvep_kernel_prop.c
 DUCKVEP_THEFT_PATCH = test/duckvep/vendor/patches/theft-mingw-no-fork.patch
 DUCKVEP_PROPERTY_CPPFLAGS ?=

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 # DuckHTS Extension News
 
 # duckhts 1.5.1.9000
+- add a caller-owned native carrier index for phased-execution development:
+  preserve explicit sample/phase-set/lane keys, share event prefixes, drain
+  distinct occupied paths and recycle slots at transcript completion. Dense
+  matrix properties and the Haplosaurus mechanics gate exercise the index;
+  no public phased SQL function or genotype phase policy is introduced
+
 - make the internal DuckVEP CDS rebuild reject coincident insertion sites,
   matching interaction partitioning instead of choosing ALT order from input.
   Exhaustive native tests compare both edit orders, both transcript strands,

--- a/r/Rduckhts/inst/duckhts_extension/duckhts_sources.tsv
+++ b/r/Rduckhts/inst/duckhts_extension/duckhts_sources.tsv
@@ -37,6 +37,7 @@ src/duckvep/kernel/src/duckvep_hgvs.c|duckvep/kernel/src/duckvep_hgvs.c
 src/duckvep/kernel/src/duckvep_codon.c|duckvep/kernel/src/duckvep_codon.c
 src/duckvep/kernel/src/duckvep_coding.c|duckvep/kernel/src/duckvep_coding.c
 src/duckvep/kernel/src/duckvep_haplotype.c|duckvep/kernel/src/duckvep_haplotype.c
+src/duckvep/kernel/src/duckvep_carriers.c|duckvep/kernel/src/duckvep_carriers.c
 src/duckvep/duckvep_model.c|duckvep/duckvep_model.c
 src/duckvep/duckvep_annotate.c|duckvep/duckvep_annotate.c
 src/duckvep/duckvep_ensembl.c|duckvep/duckvep_ensembl.c

--- a/r/Rduckhts/inst/duckhts_extension/duckvep/kernel/src/duckvep_carriers.c
+++ b/r/Rduckhts/inst/duckhts_extension/duckvep/kernel/src/duckvep_carriers.c
@@ -88,6 +88,47 @@ static int valid_pool(const void *slots, uint32_t capacity, size_t size,
         bucket_count >= 2u * capacity && (bucket_count & (bucket_count - 1u)) == 0u;
 }
 
+/* The active array is an expiry min-heap. Input advances inspect only its
+ * earliest transcript; opening/closing one path updates O(log active) slots. */
+static int expires_before(const duckvep_carriers_t *s, uint32_t left, uint32_t right) {
+    uint32_t a = s->buffers.transcripts[left - 1u].transcript_index;
+    uint32_t b = s->buffers.transcripts[right - 1u].transcript_index;
+    if (s->model->chrom_id[a] != s->model->chrom_id[b])
+        return s->model->chrom_id[a] < s->model->chrom_id[b];
+    if (s->model->end1[a] != s->model->end1[b]) return s->model->end1[a] < s->model->end1[b];
+    return a < b;
+}
+
+static void open_transcript(duckvep_carriers_t *s, uint32_t id) {
+    uint32_t at = s->transcript_count++;
+    while (at) {
+        uint32_t parent = (at - 1u) / 2u;
+        uint32_t parent_id = s->buffers.active_transcripts[parent];
+        if (!expires_before(s, id, parent_id)) break;
+        s->buffers.active_transcripts[at] = parent_id;
+        at = parent;
+    }
+    s->buffers.active_transcripts[at] = id;
+}
+
+static void close_transcript(duckvep_carriers_t *s) {
+    uint32_t count = --s->transcript_count;
+    uint32_t last = s->buffers.active_transcripts[count];
+    s->buffers.active_transcripts[count] = 0u;
+    if (!count) return;
+    uint32_t at = 0u;
+    while (2u * at + 1u < count) {
+        uint32_t child = 2u * at + 1u;
+        if (child + 1u < count && expires_before(s, s->buffers.active_transcripts[child + 1u],
+                                                s->buffers.active_transcripts[child])) child++;
+        uint32_t child_id = s->buffers.active_transcripts[child];
+        if (!expires_before(s, child_id, last)) break;
+        s->buffers.active_transcripts[at] = child_id;
+        at = child;
+    }
+    s->buffers.active_transcripts[at] = last;
+}
+
 duckvep_carriers_status_t duckvep_carriers_init(
     duckvep_carriers_t *s, const duckvep_transcript_model_t *model,
     const duckvep_carrier_buffers_t *b) {
@@ -152,8 +193,8 @@ static duckvep_carriers_status_t advance(
         *completed = s->buffers.transcripts[s->closing - 1u].transcript_index;
         return DUCKVEP_CARRIERS_TRANSCRIPT_READY;
     }
-    for (uint32_t i = 0u; i < s->transcript_count; i++) {
-        uint32_t id = s->buffers.active_transcripts[i];
+    if (s->transcript_count) {
+        uint32_t id = s->buffers.active_transcripts[0];
         const duckvep_carrier_transcript_t *tx = &s->buffers.transcripts[id - 1u];
         uint32_t ordinal = tx->transcript_index;
         if (eof || s->model->chrom_id[ordinal] < chrom ||
@@ -216,8 +257,7 @@ duckvep_carriers_status_t duckvep_carriers_push(
         s->free_transcript = tx->next_free;
         memset(tx, 0, sizeof(*tx));
         tx->transcript_index = tx_index;
-        tx->active_pos = s->transcript_count;
-        s->buffers.active_transcripts[s->transcript_count++] = tx_id;
+        open_transcript(s, tx_id);
         s->buffers.transcript_index[tx_at] = (duckvep_carrier_bucket_t){mix(tx_index), tx_id};
     }
     if (!prefix_id) {
@@ -342,9 +382,7 @@ duckvep_carriers_status_t duckvep_carriers_release(duckvep_carriers_t *s) {
     }
     (void)find_transcript(s, tx->transcript_index, &at);
     remove_bucket(s->buffers.transcript_index, s->buffers.transcript_buckets, at);
-    uint32_t last = s->buffers.active_transcripts[--s->transcript_count];
-    s->buffers.active_transcripts[tx->active_pos] = last;
-    s->buffers.transcripts[last - 1u].active_pos = tx->active_pos;
+    close_transcript(s);
     tx->next_free = s->free_transcript;
     s->free_transcript = tx_id;
     s->closing = 0u;

--- a/r/Rduckhts/inst/duckhts_extension/duckvep/kernel/src/duckvep_carriers.c
+++ b/r/Rduckhts/inst/duckhts_extension/duckvep/kernel/src/duckvep_carriers.c
@@ -1,0 +1,353 @@
+#include "duckvep_carriers.h"
+
+#include <string.h>
+
+static uint64_t mix(uint64_t x) {
+    x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
+    return x ^ (x >> 31);
+}
+
+static uint64_t call_hash(uint32_t tx, const duckvep_carrier_key_t *key) {
+    return mix(((uint64_t)tx << 32) | key->sample_index) ^
+        mix((uint64_t)(key->phase_set_present ? key->phase_set : 0)) ^
+        mix(((uint64_t)key->lane << 1) | key->phase_set_present);
+}
+
+static uint64_t prefix_hash(uint32_t tx, uint32_t parent, uint64_t event) {
+    return mix(((uint64_t)tx << 32) | parent) ^ mix(event);
+}
+
+/* Backshift deletion keeps lookups bounded by live entries rather than a
+ * growing history of tombstones after thousands of transcript closures. */
+static void remove_bucket(duckvep_carrier_bucket_t *buckets, uint32_t count, uint32_t at) {
+    uint32_t mask = count - 1u;
+    uint32_t next = (at + 1u) & mask;
+    while (buckets[next].id) {
+        uint32_t home = (uint32_t)buckets[next].hash & mask;
+        if (((next - home) & mask) >= ((next - at) & mask)) {
+            buckets[at] = buckets[next];
+            at = next;
+        }
+        next = (next + 1u) & mask;
+    }
+    buckets[at].id = 0u;
+}
+
+static uint32_t find_transcript(const duckvep_carriers_t *s, uint32_t tx, uint32_t *at) {
+    uint32_t count = s->buffers.transcript_buckets;
+    uint64_t hash = mix(tx);
+    *at = count ? (uint32_t)hash & (count - 1u) : 0u;
+    if (!count) return 0u;
+    while (s->buffers.transcript_index[*at].id) {
+        uint32_t id = s->buffers.transcript_index[*at].id;
+        if (s->buffers.transcripts[id - 1u].transcript_index == tx) return id;
+        *at = (*at + 1u) & (count - 1u);
+    }
+    return 0u;
+}
+
+static uint32_t find_call(const duckvep_carriers_t *s, uint32_t tx,
+                         const duckvep_carrier_key_t *key, uint32_t *at) {
+    uint32_t count = s->buffers.call_buckets;
+    uint64_t hash = call_hash(tx, key);
+    *at = count ? (uint32_t)hash & (count - 1u) : 0u;
+    if (!count) return 0u;
+    while (s->buffers.call_index[*at].id) {
+        uint32_t id = s->buffers.call_index[*at].id;
+        const duckvep_carrier_call_t *call = &s->buffers.calls[id - 1u];
+        if (call->transcript == tx && call->key.sample_index == key->sample_index &&
+            call->key.lane == key->lane && call->key.phase_set_present == key->phase_set_present &&
+            (!key->phase_set_present || call->key.phase_set == key->phase_set)) return id;
+        *at = (*at + 1u) & (count - 1u);
+    }
+    return 0u;
+}
+
+static uint32_t find_prefix(const duckvep_carriers_t *s, uint32_t tx, uint32_t parent,
+                           uint64_t event, uint32_t *at) {
+    uint32_t count = s->buffers.prefix_buckets;
+    uint64_t hash = prefix_hash(tx, parent, event);
+    *at = count ? (uint32_t)hash & (count - 1u) : 0u;
+    if (!count) return 0u;
+    while (s->buffers.prefix_index[*at].id) {
+        uint32_t id = s->buffers.prefix_index[*at].id;
+        const duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[id - 1u];
+        if (prefix->transcript == tx && prefix->parent == parent && prefix->event_id == event) return id;
+        *at = (*at + 1u) & (count - 1u);
+    }
+    return 0u;
+}
+
+static int valid_pool(const void *slots, uint32_t capacity, size_t size,
+                      const duckvep_carrier_bucket_t *buckets, uint32_t bucket_count) {
+    if (!capacity) return bucket_count == 0u;
+    if (bucket_count && sizeof(*buckets) > SIZE_MAX / (size_t)bucket_count) return 0;
+    return slots && buckets && capacity <= UINT32_MAX / 2u &&
+        capacity <= SIZE_MAX / size &&
+        bucket_count >= 2u * capacity && (bucket_count & (bucket_count - 1u)) == 0u;
+}
+
+duckvep_carriers_status_t duckvep_carriers_init(
+    duckvep_carriers_t *s, const duckvep_transcript_model_t *model,
+    const duckvep_carrier_buffers_t *b) {
+    if (!s) return DUCKVEP_CARRIERS_INVALID_ARG;
+    memset(s, 0, sizeof(*s));
+    if (!model || !b || model->transcript_count > UINT32_MAX ||
+        (model->transcript_count && (!model->chrom_id || !model->end1)) ||
+        (b->transcript_capacity && !b->active_transcripts) ||
+        !valid_pool(b->transcripts, b->transcript_capacity, sizeof(*b->transcripts),
+                    b->transcript_index, b->transcript_buckets) ||
+        !valid_pool(b->calls, b->call_capacity, sizeof(*b->calls), b->call_index, b->call_buckets) ||
+        !valid_pool(b->prefixes, b->prefix_capacity, sizeof(*b->prefixes),
+                    b->prefix_index, b->prefix_buckets)) return DUCKVEP_CARRIERS_INVALID_ARG;
+    s->model = model;
+    s->buffers = *b;
+    if (b->transcript_capacity) memset(b->active_transcripts, 0,
+                                       (size_t)b->transcript_capacity * sizeof(*b->active_transcripts));
+    for (uint32_t i = 0u; i < b->transcript_capacity; i++) {
+        memset(&b->transcripts[i], 0, sizeof(b->transcripts[i]));
+        b->transcripts[i].next_free = i + 1u < b->transcript_capacity ? i + 2u : 0u;
+    }
+    for (uint32_t i = 0u; i < b->call_capacity; i++) {
+        memset(&b->calls[i], 0, sizeof(b->calls[i]));
+        b->calls[i].next_free = i + 1u < b->call_capacity ? i + 2u : 0u;
+    }
+    for (uint32_t i = 0u; i < b->prefix_capacity; i++) {
+        memset(&b->prefixes[i], 0, sizeof(b->prefixes[i]));
+        b->prefixes[i].next_free = i + 1u < b->prefix_capacity ? i + 2u : 0u;
+    }
+    if (b->transcript_buckets) memset(b->transcript_index, 0,
+                                      (size_t)b->transcript_buckets * sizeof(*b->transcript_index));
+    if (b->call_buckets) memset(b->call_index, 0, (size_t)b->call_buckets * sizeof(*b->call_index));
+    if (b->prefix_buckets) memset(b->prefix_index, 0,
+                                 (size_t)b->prefix_buckets * sizeof(*b->prefix_index));
+    s->free_transcript = b->transcript_capacity ? 1u : 0u;
+    s->free_call = b->call_capacity ? 1u : 0u;
+    s->free_prefix = b->prefix_capacity ? 1u : 0u;
+    s->initialized = 1u;
+    return DUCKVEP_CARRIERS_OK;
+}
+
+static duckvep_carriers_status_t advance(
+    duckvep_carriers_t *s, uint16_t chrom, uint32_t pos1, uint64_t event,
+    int eof, uint32_t *completed) {
+    if (completed) *completed = UINT32_MAX;
+    if (!s || !s->initialized || !completed || (!eof && !pos1)) return DUCKVEP_CARRIERS_INVALID_ARG;
+    if (s->finished) return eof ? DUCKVEP_CARRIERS_DONE : DUCKVEP_CARRIERS_INPUT_ORDER;
+    if (s->pending) {
+        if (s->pending_eof != eof || (!eof && (chrom != s->pending_chrom ||
+            pos1 != s->pending_pos1 || event != s->pending_event_id))) return DUCKVEP_CARRIERS_INPUT_ORDER;
+    } else {
+        if (!eof && s->have_event && (chrom < s->chrom ||
+            (chrom == s->chrom && (pos1 < s->pos1 ||
+             (pos1 == s->pos1 && event < s->event_id))))) return DUCKVEP_CARRIERS_INPUT_ORDER;
+        s->pending = 1u;
+        s->pending_eof = (uint8_t)eof;
+        s->pending_chrom = chrom;
+        s->pending_pos1 = pos1;
+        s->pending_event_id = event;
+    }
+    if (s->closing) {
+        *completed = s->buffers.transcripts[s->closing - 1u].transcript_index;
+        return DUCKVEP_CARRIERS_TRANSCRIPT_READY;
+    }
+    for (uint32_t i = 0u; i < s->transcript_count; i++) {
+        uint32_t id = s->buffers.active_transcripts[i];
+        const duckvep_carrier_transcript_t *tx = &s->buffers.transcripts[id - 1u];
+        uint32_t ordinal = tx->transcript_index;
+        if (eof || s->model->chrom_id[ordinal] < chrom ||
+            (s->model->chrom_id[ordinal] == chrom && s->model->end1[ordinal] < pos1)) {
+            s->closing = id;
+            s->next_leaf = tx->first_prefix;
+            s->drained = 0u;
+            *completed = ordinal;
+            return DUCKVEP_CARRIERS_TRANSCRIPT_READY;
+        }
+    }
+    s->pending = 0u;
+    if (eof) {
+        s->finished = 1u;
+        return DUCKVEP_CARRIERS_DONE;
+    }
+    s->chrom = chrom;
+    s->pos1 = pos1;
+    s->event_id = event;
+    s->have_event = 1u;
+    return DUCKVEP_CARRIERS_OK;
+}
+
+duckvep_carriers_status_t duckvep_carriers_advance(
+    duckvep_carriers_t *s, uint16_t chrom, uint32_t pos1, uint64_t event,
+    uint32_t *completed) {
+    return advance(s, chrom, pos1, event, 0, completed);
+}
+
+duckvep_carriers_status_t duckvep_carriers_finish(duckvep_carriers_t *s, uint32_t *completed) {
+    return advance(s, 0u, 0u, 0u, 1, completed);
+}
+
+duckvep_carriers_status_t duckvep_carriers_push(
+    duckvep_carriers_t *s, uint32_t tx_index, const duckvep_carrier_key_t *key) {
+    uint32_t tx_at, call_at, prefix_at;
+    if (!s || !s->initialized || !key || !s->have_event || s->finished || s->pending ||
+        tx_index >= s->model->transcript_count || !key->lane || key->lane > key->ploidy ||
+        key->phase_set_present > 1u || s->model->chrom_id[tx_index] != s->chrom ||
+        s->model->end1[tx_index] < s->pos1) return DUCKVEP_CARRIERS_INVALID_ARG;
+    uint32_t tx_id = find_transcript(s, tx_index, &tx_at);
+    int new_tx = !tx_id;
+    if (new_tx) {
+        if (!s->free_transcript) return DUCKVEP_CARRIERS_TRANSCRIPT_FULL;
+        tx_id = s->free_transcript;
+    }
+    uint32_t call_id = find_call(s, tx_id, key, &call_at);
+    uint32_t parent = call_id ? s->buffers.calls[call_id - 1u].leaf : 0u;
+    if (call_id && s->buffers.calls[call_id - 1u].key.ploidy != key->ploidy)
+        return DUCKVEP_CARRIERS_PLOIDY_CONFLICT;
+    if (parent && s->buffers.prefixes[parent - 1u].event_id == s->event_id)
+        return DUCKVEP_CARRIERS_DUPLICATE_CALL;
+    if (!call_id && !s->free_call) return DUCKVEP_CARRIERS_CALL_FULL;
+    uint32_t prefix_id = find_prefix(s, tx_id, parent, s->event_id, &prefix_at);
+    if (!prefix_id && !s->free_prefix) return DUCKVEP_CARRIERS_PREFIX_FULL;
+
+    /* Every capacity and key check precedes publication of any new slot. */
+    duckvep_carrier_transcript_t *tx = &s->buffers.transcripts[tx_id - 1u];
+    if (new_tx) {
+        s->free_transcript = tx->next_free;
+        memset(tx, 0, sizeof(*tx));
+        tx->transcript_index = tx_index;
+        tx->active_pos = s->transcript_count;
+        s->buffers.active_transcripts[s->transcript_count++] = tx_id;
+        s->buffers.transcript_index[tx_at] = (duckvep_carrier_bucket_t){mix(tx_index), tx_id};
+    }
+    if (!prefix_id) {
+        prefix_id = s->free_prefix;
+        duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[prefix_id - 1u];
+        s->free_prefix = prefix->next_free;
+        memset(prefix, 0, sizeof(*prefix));
+        prefix->event_id = s->event_id;
+        prefix->transcript = tx_id;
+        prefix->parent = parent;
+        prefix->depth = parent ? s->buffers.prefixes[parent - 1u].depth + 1u : 1u;
+        prefix->next_transcript = tx->first_prefix;
+        tx->first_prefix = prefix_id;
+        s->buffers.prefix_index[prefix_at] = (duckvep_carrier_bucket_t){
+            prefix_hash(tx_id, parent, s->event_id), prefix_id};
+        s->prefix_count++;
+    }
+    if (!call_id) {
+        call_id = s->free_call;
+        duckvep_carrier_call_t *call = &s->buffers.calls[call_id - 1u];
+        s->free_call = call->next_free;
+        memset(call, 0, sizeof(*call));
+        call->key = *key;
+        if (!key->phase_set_present) call->key.phase_set = 0;
+        call->transcript = tx_id;
+        call->next_transcript = tx->first_call;
+        tx->first_call = call_id;
+        s->buffers.call_index[call_at] = (duckvep_carrier_bucket_t){call_hash(tx_id, key), call_id};
+        s->call_count++;
+    }
+    duckvep_carrier_call_t *call = &s->buffers.calls[call_id - 1u];
+    if (parent) {
+        duckvep_carrier_prefix_t *old = &s->buffers.prefixes[parent - 1u];
+        if (call->previous_leaf) s->buffers.calls[call->previous_leaf - 1u].next_leaf = call->next_leaf;
+        else old->first_call = call->next_leaf;
+        if (call->next_leaf) s->buffers.calls[call->next_leaf - 1u].previous_leaf = call->previous_leaf;
+        old->call_count--;
+    }
+    duckvep_carrier_prefix_t *leaf = &s->buffers.prefixes[prefix_id - 1u];
+    call->leaf = prefix_id;
+    call->previous_leaf = 0u;
+    call->next_leaf = leaf->first_call;
+    if (leaf->first_call) s->buffers.calls[leaf->first_call - 1u].previous_leaf = call_id;
+    leaf->first_call = call_id;
+    leaf->call_count++;
+    if (s->transcript_count > s->peak_transcripts) s->peak_transcripts = s->transcript_count;
+    if (s->call_count > s->peak_calls) s->peak_calls = s->call_count;
+    if (s->prefix_count > s->peak_prefixes) s->peak_prefixes = s->prefix_count;
+    return DUCKVEP_CARRIERS_OK;
+}
+
+duckvep_carriers_status_t duckvep_carriers_next_leaf(
+    duckvep_carriers_t *s, duckvep_carrier_leaf_t *leaf) {
+    if (leaf) memset(leaf, 0, sizeof(*leaf));
+    if (!s || !s->initialized || !s->closing || !leaf) return DUCKVEP_CARRIERS_INVALID_ARG;
+    while (s->next_leaf) {
+        uint32_t id = s->next_leaf;
+        const duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[id - 1u];
+        s->next_leaf = prefix->next_transcript;
+        if (!prefix->call_count) continue;
+        *leaf = (duckvep_carrier_leaf_t){id,
+            s->buffers.transcripts[s->closing - 1u].transcript_index,
+            prefix->depth, prefix->first_call, prefix->call_count};
+        return DUCKVEP_CARRIERS_OK;
+    }
+    s->drained = 1u;
+    return DUCKVEP_CARRIERS_DONE;
+}
+
+duckvep_carriers_status_t duckvep_carriers_leaf_events(
+    const duckvep_carriers_t *s, uint32_t id, uint64_t *events,
+    size_t capacity, size_t *required) {
+    if (required) *required = 0u;
+    if (!s || !s->initialized || !s->closing || !required || !id ||
+        id > s->buffers.prefix_capacity || (capacity && !events)) return DUCKVEP_CARRIERS_INVALID_ARG;
+    const duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[id - 1u];
+    if (prefix->transcript != s->closing || !prefix->call_count) return DUCKVEP_CARRIERS_INVALID_ARG;
+    *required = prefix->depth;
+    if (capacity < *required) return DUCKVEP_CARRIERS_OUTPUT_FULL;
+    size_t at = *required;
+    while (id) {
+        prefix = &s->buffers.prefixes[id - 1u];
+        events[--at] = prefix->event_id;
+        id = prefix->parent;
+    }
+    return DUCKVEP_CARRIERS_OK;
+}
+
+const duckvep_carrier_call_t *duckvep_carriers_call(const duckvep_carriers_t *s, uint32_t id) {
+    if (!s || !s->initialized || !s->closing || !id || id > s->buffers.call_capacity) return NULL;
+    const duckvep_carrier_call_t *call = &s->buffers.calls[id - 1u];
+    return call->transcript == s->closing ? call : NULL;
+}
+
+duckvep_carriers_status_t duckvep_carriers_release(duckvep_carriers_t *s) {
+    if (!s || !s->initialized || !s->closing || !s->drained) return DUCKVEP_CARRIERS_INVALID_ARG;
+    uint32_t tx_id = s->closing;
+    duckvep_carrier_transcript_t *tx = &s->buffers.transcripts[tx_id - 1u];
+    uint32_t id = tx->first_call, at;
+    while (id) {
+        duckvep_carrier_call_t *call = &s->buffers.calls[id - 1u];
+        uint32_t next = call->next_transcript;
+        (void)find_call(s, tx_id, &call->key, &at);
+        remove_bucket(s->buffers.call_index, s->buffers.call_buckets, at);
+        call->transcript = 0u;
+        call->next_free = s->free_call;
+        s->free_call = id;
+        s->call_count--;
+        id = next;
+    }
+    id = tx->first_prefix;
+    while (id) {
+        duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[id - 1u];
+        uint32_t next = prefix->next_transcript;
+        (void)find_prefix(s, tx_id, prefix->parent, prefix->event_id, &at);
+        remove_bucket(s->buffers.prefix_index, s->buffers.prefix_buckets, at);
+        prefix->transcript = 0u;
+        prefix->next_free = s->free_prefix;
+        s->free_prefix = id;
+        s->prefix_count--;
+        id = next;
+    }
+    (void)find_transcript(s, tx->transcript_index, &at);
+    remove_bucket(s->buffers.transcript_index, s->buffers.transcript_buckets, at);
+    uint32_t last = s->buffers.active_transcripts[--s->transcript_count];
+    s->buffers.active_transcripts[tx->active_pos] = last;
+    s->buffers.transcripts[last - 1u].active_pos = tx->active_pos;
+    tx->next_free = s->free_transcript;
+    s->free_transcript = tx_id;
+    s->closing = 0u;
+    s->drained = 0u;
+    return DUCKVEP_CARRIERS_OK;
+}

--- a/r/Rduckhts/inst/duckhts_extension/duckvep/kernel/src/duckvep_carriers.h
+++ b/r/Rduckhts/inst/duckhts_extension/duckvep/kernel/src/duckvep_carriers.h
@@ -1,0 +1,129 @@
+/* Sparse, model-scoped carrier paths over projected event identities (INTERNAL).
+ * No allocation, DuckDB, HTSlib, phase-policy inference or allele decoding.
+ *
+ * The owner pins one immutable transcript model and owns all buffers. Projected
+ * alleles/provenance stay in its event store until a transcript is drained.
+ * This index stores only event IDs: identical prefixes share nodes across
+ * samples/phase sets/lanes; reference paths require no entry. Input is ordered
+ * by (chrom_id, pos1, event_id), with a unique event ID per source event. Calls
+ * for one event may span arbitrarily many input batches.
+ *
+ * advance/finish report a completed transcript before accepting further input.
+ * Drain its distinct leaves, materialize each leaf and its carrier list, then
+ * release it. All returned IDs/views expire at release. Releasing returns the
+ * transcript's slots to the pools; memory does not grow with past transcripts.
+ */
+#ifndef DUCKVEP_CARRIERS_H
+#define DUCKVEP_CARRIERS_H
+
+#include "duckvep_kernel.h"
+
+typedef enum {
+    DUCKVEP_CARRIERS_OK,
+    DUCKVEP_CARRIERS_TRANSCRIPT_READY,
+    DUCKVEP_CARRIERS_DONE,
+    DUCKVEP_CARRIERS_INVALID_ARG,
+    DUCKVEP_CARRIERS_INPUT_ORDER,
+    DUCKVEP_CARRIERS_TRANSCRIPT_FULL,
+    DUCKVEP_CARRIERS_CALL_FULL,
+    DUCKVEP_CARRIERS_PREFIX_FULL,
+    DUCKVEP_CARRIERS_OUTPUT_FULL,
+    DUCKVEP_CARRIERS_DUPLICATE_CALL,
+    DUCKVEP_CARRIERS_PLOIDY_CONFLICT
+} duckvep_carriers_status_t;
+
+typedef struct {
+    uint32_t sample_index;
+    int64_t phase_set;
+    uint16_t lane;                  /* One-based, at most ploidy. */
+    uint16_t ploidy;
+    uint8_t phase_set_present;      /* Absent and a present PS=0 are distinct. */
+} duckvep_carrier_key_t;
+
+/* Slots and hash buckets are caller-owned implementation storage. A zero ID
+ * means no slot; live IDs are one-based offsets into their respective arrays. */
+typedef struct {
+    uint64_t hash;
+    uint32_t id;
+} duckvep_carrier_bucket_t;
+
+typedef struct {
+    uint32_t transcript_index, active_pos;
+    uint32_t first_call, first_prefix, next_free;
+} duckvep_carrier_transcript_t;
+
+typedef struct {
+    duckvep_carrier_key_t key;
+    uint32_t transcript, leaf, next_transcript, next_leaf, previous_leaf, next_free;
+} duckvep_carrier_call_t;
+
+typedef struct {
+    uint64_t event_id;
+    uint32_t transcript, parent, depth, first_call, call_count, next_transcript, next_free;
+} duckvep_carrier_prefix_t;
+
+typedef struct {
+    duckvep_carrier_transcript_t *transcripts;
+    duckvep_carrier_call_t *calls;
+    duckvep_carrier_prefix_t *prefixes;
+    uint32_t *active_transcripts;
+    duckvep_carrier_bucket_t *transcript_index, *call_index, *prefix_index;
+    uint32_t transcript_capacity, call_capacity, prefix_capacity;
+    uint32_t transcript_buckets, call_buckets, prefix_buckets;
+} duckvep_carrier_buffers_t;
+
+typedef struct {
+    const duckvep_transcript_model_t *model;
+    duckvep_carrier_buffers_t buffers;
+    uint32_t free_transcript, free_call, free_prefix;
+    uint32_t transcript_count, call_count, prefix_count;
+    uint32_t peak_transcripts, peak_calls, peak_prefixes;
+    uint32_t closing, next_leaf;
+    uint32_t pos1, pending_pos1;
+    uint64_t event_id, pending_event_id;
+    uint16_t chrom, pending_chrom;
+    uint8_t initialized, have_event, pending, pending_eof, finished, drained;
+} duckvep_carriers_t;
+
+typedef struct {
+    uint32_t id, transcript_index, event_count, first_call, call_count;
+} duckvep_carrier_leaf_t;
+
+/* Buffer arrays must be distinct. Each hash size is a power of two at least
+ * twice its pool capacity, or both sizes are zero. Init clears all storage. */
+duckvep_carriers_status_t duckvep_carriers_init(
+    duckvep_carriers_t *stream, const duckvep_transcript_model_t *model,
+    const duckvep_carrier_buffers_t *buffers);
+
+/* Retry the same tuple after draining each TRANSCRIPT_READY. The completed
+ * model-local ordinal is written to transcript_index. Equal tuples continue
+ * the same event across batches; decreasing tuples fail without mutation. */
+duckvep_carriers_status_t duckvep_carriers_advance(
+    duckvep_carriers_t *stream, uint16_t chrom, uint32_t pos1, uint64_t event_id,
+    uint32_t *transcript_index);
+duckvep_carriers_status_t duckvep_carriers_finish(
+    duckvep_carriers_t *stream, uint32_t *transcript_index);
+
+/* Append the current non-reference event to one carrier. Capacity failures,
+ * duplicate calls and changed ploidy for an existing carrier key leave all
+ * path/pool state unchanged.
+ * Phase interpretation belongs to the consumer; this preserves explicit keys. */
+duckvep_carriers_status_t duckvep_carriers_push(
+    duckvep_carriers_t *stream, uint32_t transcript_index,
+    const duckvep_carrier_key_t *key);
+
+/* Each distinct occupied prefix is emitted once, including a prefix that is
+ * both a completed carrier path and an ancestor of a longer carrier path. */
+duckvep_carriers_status_t duckvep_carriers_next_leaf(
+    duckvep_carriers_t *stream, duckvep_carrier_leaf_t *leaf);
+/* Event IDs are returned in arrival order. No output is written on OUTPUT_FULL. */
+duckvep_carriers_status_t duckvep_carriers_leaf_events(
+    const duckvep_carriers_t *stream, uint32_t leaf, uint64_t *events,
+    size_t capacity, size_t *required);
+/* Iterate from leaf.first_call through next_leaf. Borrowed until release. */
+const duckvep_carrier_call_t *duckvep_carriers_call(
+    const duckvep_carriers_t *stream, uint32_t call);
+/* Requires next_leaf to have returned DONE. No other transcript is released. */
+duckvep_carriers_status_t duckvep_carriers_release(duckvep_carriers_t *stream);
+
+#endif

--- a/r/Rduckhts/inst/duckhts_extension/duckvep/kernel/src/duckvep_carriers.h
+++ b/r/Rduckhts/inst/duckhts_extension/duckvep/kernel/src/duckvep_carriers.h
@@ -48,7 +48,7 @@ typedef struct {
 } duckvep_carrier_bucket_t;
 
 typedef struct {
-    uint32_t transcript_index, active_pos;
+    uint32_t transcript_index;
     uint32_t first_call, first_prefix, next_free;
 } duckvep_carrier_transcript_t;
 
@@ -66,7 +66,7 @@ typedef struct {
     duckvep_carrier_transcript_t *transcripts;
     duckvep_carrier_call_t *calls;
     duckvep_carrier_prefix_t *prefixes;
-    uint32_t *active_transcripts;
+    uint32_t *active_transcripts;   /* Min-heap by model chromosome, end, ordinal. */
     duckvep_carrier_bucket_t *transcript_index, *call_index, *prefix_index;
     uint32_t transcript_capacity, call_capacity, prefix_capacity;
     uint32_t transcript_buckets, call_buckets, prefix_buckets;

--- a/src/duckhts_sources.tsv
+++ b/src/duckhts_sources.tsv
@@ -37,6 +37,7 @@ src/duckvep/kernel/src/duckvep_hgvs.c|duckvep/kernel/src/duckvep_hgvs.c
 src/duckvep/kernel/src/duckvep_codon.c|duckvep/kernel/src/duckvep_codon.c
 src/duckvep/kernel/src/duckvep_coding.c|duckvep/kernel/src/duckvep_coding.c
 src/duckvep/kernel/src/duckvep_haplotype.c|duckvep/kernel/src/duckvep_haplotype.c
+src/duckvep/kernel/src/duckvep_carriers.c|duckvep/kernel/src/duckvep_carriers.c
 src/duckvep/duckvep_model.c|duckvep/duckvep_model.c
 src/duckvep/duckvep_annotate.c|duckvep/duckvep_annotate.c
 src/duckvep/duckvep_ensembl.c|duckvep/duckvep_ensembl.c

--- a/src/duckvep/kernel/src/duckvep_carriers.c
+++ b/src/duckvep/kernel/src/duckvep_carriers.c
@@ -88,6 +88,47 @@ static int valid_pool(const void *slots, uint32_t capacity, size_t size,
         bucket_count >= 2u * capacity && (bucket_count & (bucket_count - 1u)) == 0u;
 }
 
+/* The active array is an expiry min-heap. Input advances inspect only its
+ * earliest transcript; opening/closing one path updates O(log active) slots. */
+static int expires_before(const duckvep_carriers_t *s, uint32_t left, uint32_t right) {
+    uint32_t a = s->buffers.transcripts[left - 1u].transcript_index;
+    uint32_t b = s->buffers.transcripts[right - 1u].transcript_index;
+    if (s->model->chrom_id[a] != s->model->chrom_id[b])
+        return s->model->chrom_id[a] < s->model->chrom_id[b];
+    if (s->model->end1[a] != s->model->end1[b]) return s->model->end1[a] < s->model->end1[b];
+    return a < b;
+}
+
+static void open_transcript(duckvep_carriers_t *s, uint32_t id) {
+    uint32_t at = s->transcript_count++;
+    while (at) {
+        uint32_t parent = (at - 1u) / 2u;
+        uint32_t parent_id = s->buffers.active_transcripts[parent];
+        if (!expires_before(s, id, parent_id)) break;
+        s->buffers.active_transcripts[at] = parent_id;
+        at = parent;
+    }
+    s->buffers.active_transcripts[at] = id;
+}
+
+static void close_transcript(duckvep_carriers_t *s) {
+    uint32_t count = --s->transcript_count;
+    uint32_t last = s->buffers.active_transcripts[count];
+    s->buffers.active_transcripts[count] = 0u;
+    if (!count) return;
+    uint32_t at = 0u;
+    while (2u * at + 1u < count) {
+        uint32_t child = 2u * at + 1u;
+        if (child + 1u < count && expires_before(s, s->buffers.active_transcripts[child + 1u],
+                                                s->buffers.active_transcripts[child])) child++;
+        uint32_t child_id = s->buffers.active_transcripts[child];
+        if (!expires_before(s, child_id, last)) break;
+        s->buffers.active_transcripts[at] = child_id;
+        at = child;
+    }
+    s->buffers.active_transcripts[at] = last;
+}
+
 duckvep_carriers_status_t duckvep_carriers_init(
     duckvep_carriers_t *s, const duckvep_transcript_model_t *model,
     const duckvep_carrier_buffers_t *b) {
@@ -152,8 +193,8 @@ static duckvep_carriers_status_t advance(
         *completed = s->buffers.transcripts[s->closing - 1u].transcript_index;
         return DUCKVEP_CARRIERS_TRANSCRIPT_READY;
     }
-    for (uint32_t i = 0u; i < s->transcript_count; i++) {
-        uint32_t id = s->buffers.active_transcripts[i];
+    if (s->transcript_count) {
+        uint32_t id = s->buffers.active_transcripts[0];
         const duckvep_carrier_transcript_t *tx = &s->buffers.transcripts[id - 1u];
         uint32_t ordinal = tx->transcript_index;
         if (eof || s->model->chrom_id[ordinal] < chrom ||
@@ -216,8 +257,7 @@ duckvep_carriers_status_t duckvep_carriers_push(
         s->free_transcript = tx->next_free;
         memset(tx, 0, sizeof(*tx));
         tx->transcript_index = tx_index;
-        tx->active_pos = s->transcript_count;
-        s->buffers.active_transcripts[s->transcript_count++] = tx_id;
+        open_transcript(s, tx_id);
         s->buffers.transcript_index[tx_at] = (duckvep_carrier_bucket_t){mix(tx_index), tx_id};
     }
     if (!prefix_id) {
@@ -342,9 +382,7 @@ duckvep_carriers_status_t duckvep_carriers_release(duckvep_carriers_t *s) {
     }
     (void)find_transcript(s, tx->transcript_index, &at);
     remove_bucket(s->buffers.transcript_index, s->buffers.transcript_buckets, at);
-    uint32_t last = s->buffers.active_transcripts[--s->transcript_count];
-    s->buffers.active_transcripts[tx->active_pos] = last;
-    s->buffers.transcripts[last - 1u].active_pos = tx->active_pos;
+    close_transcript(s);
     tx->next_free = s->free_transcript;
     s->free_transcript = tx_id;
     s->closing = 0u;

--- a/src/duckvep/kernel/src/duckvep_carriers.c
+++ b/src/duckvep/kernel/src/duckvep_carriers.c
@@ -1,0 +1,353 @@
+#include "duckvep_carriers.h"
+
+#include <string.h>
+
+static uint64_t mix(uint64_t x) {
+    x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
+    return x ^ (x >> 31);
+}
+
+static uint64_t call_hash(uint32_t tx, const duckvep_carrier_key_t *key) {
+    return mix(((uint64_t)tx << 32) | key->sample_index) ^
+        mix((uint64_t)(key->phase_set_present ? key->phase_set : 0)) ^
+        mix(((uint64_t)key->lane << 1) | key->phase_set_present);
+}
+
+static uint64_t prefix_hash(uint32_t tx, uint32_t parent, uint64_t event) {
+    return mix(((uint64_t)tx << 32) | parent) ^ mix(event);
+}
+
+/* Backshift deletion keeps lookups bounded by live entries rather than a
+ * growing history of tombstones after thousands of transcript closures. */
+static void remove_bucket(duckvep_carrier_bucket_t *buckets, uint32_t count, uint32_t at) {
+    uint32_t mask = count - 1u;
+    uint32_t next = (at + 1u) & mask;
+    while (buckets[next].id) {
+        uint32_t home = (uint32_t)buckets[next].hash & mask;
+        if (((next - home) & mask) >= ((next - at) & mask)) {
+            buckets[at] = buckets[next];
+            at = next;
+        }
+        next = (next + 1u) & mask;
+    }
+    buckets[at].id = 0u;
+}
+
+static uint32_t find_transcript(const duckvep_carriers_t *s, uint32_t tx, uint32_t *at) {
+    uint32_t count = s->buffers.transcript_buckets;
+    uint64_t hash = mix(tx);
+    *at = count ? (uint32_t)hash & (count - 1u) : 0u;
+    if (!count) return 0u;
+    while (s->buffers.transcript_index[*at].id) {
+        uint32_t id = s->buffers.transcript_index[*at].id;
+        if (s->buffers.transcripts[id - 1u].transcript_index == tx) return id;
+        *at = (*at + 1u) & (count - 1u);
+    }
+    return 0u;
+}
+
+static uint32_t find_call(const duckvep_carriers_t *s, uint32_t tx,
+                         const duckvep_carrier_key_t *key, uint32_t *at) {
+    uint32_t count = s->buffers.call_buckets;
+    uint64_t hash = call_hash(tx, key);
+    *at = count ? (uint32_t)hash & (count - 1u) : 0u;
+    if (!count) return 0u;
+    while (s->buffers.call_index[*at].id) {
+        uint32_t id = s->buffers.call_index[*at].id;
+        const duckvep_carrier_call_t *call = &s->buffers.calls[id - 1u];
+        if (call->transcript == tx && call->key.sample_index == key->sample_index &&
+            call->key.lane == key->lane && call->key.phase_set_present == key->phase_set_present &&
+            (!key->phase_set_present || call->key.phase_set == key->phase_set)) return id;
+        *at = (*at + 1u) & (count - 1u);
+    }
+    return 0u;
+}
+
+static uint32_t find_prefix(const duckvep_carriers_t *s, uint32_t tx, uint32_t parent,
+                           uint64_t event, uint32_t *at) {
+    uint32_t count = s->buffers.prefix_buckets;
+    uint64_t hash = prefix_hash(tx, parent, event);
+    *at = count ? (uint32_t)hash & (count - 1u) : 0u;
+    if (!count) return 0u;
+    while (s->buffers.prefix_index[*at].id) {
+        uint32_t id = s->buffers.prefix_index[*at].id;
+        const duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[id - 1u];
+        if (prefix->transcript == tx && prefix->parent == parent && prefix->event_id == event) return id;
+        *at = (*at + 1u) & (count - 1u);
+    }
+    return 0u;
+}
+
+static int valid_pool(const void *slots, uint32_t capacity, size_t size,
+                      const duckvep_carrier_bucket_t *buckets, uint32_t bucket_count) {
+    if (!capacity) return bucket_count == 0u;
+    if (bucket_count && sizeof(*buckets) > SIZE_MAX / (size_t)bucket_count) return 0;
+    return slots && buckets && capacity <= UINT32_MAX / 2u &&
+        capacity <= SIZE_MAX / size &&
+        bucket_count >= 2u * capacity && (bucket_count & (bucket_count - 1u)) == 0u;
+}
+
+duckvep_carriers_status_t duckvep_carriers_init(
+    duckvep_carriers_t *s, const duckvep_transcript_model_t *model,
+    const duckvep_carrier_buffers_t *b) {
+    if (!s) return DUCKVEP_CARRIERS_INVALID_ARG;
+    memset(s, 0, sizeof(*s));
+    if (!model || !b || model->transcript_count > UINT32_MAX ||
+        (model->transcript_count && (!model->chrom_id || !model->end1)) ||
+        (b->transcript_capacity && !b->active_transcripts) ||
+        !valid_pool(b->transcripts, b->transcript_capacity, sizeof(*b->transcripts),
+                    b->transcript_index, b->transcript_buckets) ||
+        !valid_pool(b->calls, b->call_capacity, sizeof(*b->calls), b->call_index, b->call_buckets) ||
+        !valid_pool(b->prefixes, b->prefix_capacity, sizeof(*b->prefixes),
+                    b->prefix_index, b->prefix_buckets)) return DUCKVEP_CARRIERS_INVALID_ARG;
+    s->model = model;
+    s->buffers = *b;
+    if (b->transcript_capacity) memset(b->active_transcripts, 0,
+                                       (size_t)b->transcript_capacity * sizeof(*b->active_transcripts));
+    for (uint32_t i = 0u; i < b->transcript_capacity; i++) {
+        memset(&b->transcripts[i], 0, sizeof(b->transcripts[i]));
+        b->transcripts[i].next_free = i + 1u < b->transcript_capacity ? i + 2u : 0u;
+    }
+    for (uint32_t i = 0u; i < b->call_capacity; i++) {
+        memset(&b->calls[i], 0, sizeof(b->calls[i]));
+        b->calls[i].next_free = i + 1u < b->call_capacity ? i + 2u : 0u;
+    }
+    for (uint32_t i = 0u; i < b->prefix_capacity; i++) {
+        memset(&b->prefixes[i], 0, sizeof(b->prefixes[i]));
+        b->prefixes[i].next_free = i + 1u < b->prefix_capacity ? i + 2u : 0u;
+    }
+    if (b->transcript_buckets) memset(b->transcript_index, 0,
+                                      (size_t)b->transcript_buckets * sizeof(*b->transcript_index));
+    if (b->call_buckets) memset(b->call_index, 0, (size_t)b->call_buckets * sizeof(*b->call_index));
+    if (b->prefix_buckets) memset(b->prefix_index, 0,
+                                 (size_t)b->prefix_buckets * sizeof(*b->prefix_index));
+    s->free_transcript = b->transcript_capacity ? 1u : 0u;
+    s->free_call = b->call_capacity ? 1u : 0u;
+    s->free_prefix = b->prefix_capacity ? 1u : 0u;
+    s->initialized = 1u;
+    return DUCKVEP_CARRIERS_OK;
+}
+
+static duckvep_carriers_status_t advance(
+    duckvep_carriers_t *s, uint16_t chrom, uint32_t pos1, uint64_t event,
+    int eof, uint32_t *completed) {
+    if (completed) *completed = UINT32_MAX;
+    if (!s || !s->initialized || !completed || (!eof && !pos1)) return DUCKVEP_CARRIERS_INVALID_ARG;
+    if (s->finished) return eof ? DUCKVEP_CARRIERS_DONE : DUCKVEP_CARRIERS_INPUT_ORDER;
+    if (s->pending) {
+        if (s->pending_eof != eof || (!eof && (chrom != s->pending_chrom ||
+            pos1 != s->pending_pos1 || event != s->pending_event_id))) return DUCKVEP_CARRIERS_INPUT_ORDER;
+    } else {
+        if (!eof && s->have_event && (chrom < s->chrom ||
+            (chrom == s->chrom && (pos1 < s->pos1 ||
+             (pos1 == s->pos1 && event < s->event_id))))) return DUCKVEP_CARRIERS_INPUT_ORDER;
+        s->pending = 1u;
+        s->pending_eof = (uint8_t)eof;
+        s->pending_chrom = chrom;
+        s->pending_pos1 = pos1;
+        s->pending_event_id = event;
+    }
+    if (s->closing) {
+        *completed = s->buffers.transcripts[s->closing - 1u].transcript_index;
+        return DUCKVEP_CARRIERS_TRANSCRIPT_READY;
+    }
+    for (uint32_t i = 0u; i < s->transcript_count; i++) {
+        uint32_t id = s->buffers.active_transcripts[i];
+        const duckvep_carrier_transcript_t *tx = &s->buffers.transcripts[id - 1u];
+        uint32_t ordinal = tx->transcript_index;
+        if (eof || s->model->chrom_id[ordinal] < chrom ||
+            (s->model->chrom_id[ordinal] == chrom && s->model->end1[ordinal] < pos1)) {
+            s->closing = id;
+            s->next_leaf = tx->first_prefix;
+            s->drained = 0u;
+            *completed = ordinal;
+            return DUCKVEP_CARRIERS_TRANSCRIPT_READY;
+        }
+    }
+    s->pending = 0u;
+    if (eof) {
+        s->finished = 1u;
+        return DUCKVEP_CARRIERS_DONE;
+    }
+    s->chrom = chrom;
+    s->pos1 = pos1;
+    s->event_id = event;
+    s->have_event = 1u;
+    return DUCKVEP_CARRIERS_OK;
+}
+
+duckvep_carriers_status_t duckvep_carriers_advance(
+    duckvep_carriers_t *s, uint16_t chrom, uint32_t pos1, uint64_t event,
+    uint32_t *completed) {
+    return advance(s, chrom, pos1, event, 0, completed);
+}
+
+duckvep_carriers_status_t duckvep_carriers_finish(duckvep_carriers_t *s, uint32_t *completed) {
+    return advance(s, 0u, 0u, 0u, 1, completed);
+}
+
+duckvep_carriers_status_t duckvep_carriers_push(
+    duckvep_carriers_t *s, uint32_t tx_index, const duckvep_carrier_key_t *key) {
+    uint32_t tx_at, call_at, prefix_at;
+    if (!s || !s->initialized || !key || !s->have_event || s->finished || s->pending ||
+        tx_index >= s->model->transcript_count || !key->lane || key->lane > key->ploidy ||
+        key->phase_set_present > 1u || s->model->chrom_id[tx_index] != s->chrom ||
+        s->model->end1[tx_index] < s->pos1) return DUCKVEP_CARRIERS_INVALID_ARG;
+    uint32_t tx_id = find_transcript(s, tx_index, &tx_at);
+    int new_tx = !tx_id;
+    if (new_tx) {
+        if (!s->free_transcript) return DUCKVEP_CARRIERS_TRANSCRIPT_FULL;
+        tx_id = s->free_transcript;
+    }
+    uint32_t call_id = find_call(s, tx_id, key, &call_at);
+    uint32_t parent = call_id ? s->buffers.calls[call_id - 1u].leaf : 0u;
+    if (call_id && s->buffers.calls[call_id - 1u].key.ploidy != key->ploidy)
+        return DUCKVEP_CARRIERS_PLOIDY_CONFLICT;
+    if (parent && s->buffers.prefixes[parent - 1u].event_id == s->event_id)
+        return DUCKVEP_CARRIERS_DUPLICATE_CALL;
+    if (!call_id && !s->free_call) return DUCKVEP_CARRIERS_CALL_FULL;
+    uint32_t prefix_id = find_prefix(s, tx_id, parent, s->event_id, &prefix_at);
+    if (!prefix_id && !s->free_prefix) return DUCKVEP_CARRIERS_PREFIX_FULL;
+
+    /* Every capacity and key check precedes publication of any new slot. */
+    duckvep_carrier_transcript_t *tx = &s->buffers.transcripts[tx_id - 1u];
+    if (new_tx) {
+        s->free_transcript = tx->next_free;
+        memset(tx, 0, sizeof(*tx));
+        tx->transcript_index = tx_index;
+        tx->active_pos = s->transcript_count;
+        s->buffers.active_transcripts[s->transcript_count++] = tx_id;
+        s->buffers.transcript_index[tx_at] = (duckvep_carrier_bucket_t){mix(tx_index), tx_id};
+    }
+    if (!prefix_id) {
+        prefix_id = s->free_prefix;
+        duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[prefix_id - 1u];
+        s->free_prefix = prefix->next_free;
+        memset(prefix, 0, sizeof(*prefix));
+        prefix->event_id = s->event_id;
+        prefix->transcript = tx_id;
+        prefix->parent = parent;
+        prefix->depth = parent ? s->buffers.prefixes[parent - 1u].depth + 1u : 1u;
+        prefix->next_transcript = tx->first_prefix;
+        tx->first_prefix = prefix_id;
+        s->buffers.prefix_index[prefix_at] = (duckvep_carrier_bucket_t){
+            prefix_hash(tx_id, parent, s->event_id), prefix_id};
+        s->prefix_count++;
+    }
+    if (!call_id) {
+        call_id = s->free_call;
+        duckvep_carrier_call_t *call = &s->buffers.calls[call_id - 1u];
+        s->free_call = call->next_free;
+        memset(call, 0, sizeof(*call));
+        call->key = *key;
+        if (!key->phase_set_present) call->key.phase_set = 0;
+        call->transcript = tx_id;
+        call->next_transcript = tx->first_call;
+        tx->first_call = call_id;
+        s->buffers.call_index[call_at] = (duckvep_carrier_bucket_t){call_hash(tx_id, key), call_id};
+        s->call_count++;
+    }
+    duckvep_carrier_call_t *call = &s->buffers.calls[call_id - 1u];
+    if (parent) {
+        duckvep_carrier_prefix_t *old = &s->buffers.prefixes[parent - 1u];
+        if (call->previous_leaf) s->buffers.calls[call->previous_leaf - 1u].next_leaf = call->next_leaf;
+        else old->first_call = call->next_leaf;
+        if (call->next_leaf) s->buffers.calls[call->next_leaf - 1u].previous_leaf = call->previous_leaf;
+        old->call_count--;
+    }
+    duckvep_carrier_prefix_t *leaf = &s->buffers.prefixes[prefix_id - 1u];
+    call->leaf = prefix_id;
+    call->previous_leaf = 0u;
+    call->next_leaf = leaf->first_call;
+    if (leaf->first_call) s->buffers.calls[leaf->first_call - 1u].previous_leaf = call_id;
+    leaf->first_call = call_id;
+    leaf->call_count++;
+    if (s->transcript_count > s->peak_transcripts) s->peak_transcripts = s->transcript_count;
+    if (s->call_count > s->peak_calls) s->peak_calls = s->call_count;
+    if (s->prefix_count > s->peak_prefixes) s->peak_prefixes = s->prefix_count;
+    return DUCKVEP_CARRIERS_OK;
+}
+
+duckvep_carriers_status_t duckvep_carriers_next_leaf(
+    duckvep_carriers_t *s, duckvep_carrier_leaf_t *leaf) {
+    if (leaf) memset(leaf, 0, sizeof(*leaf));
+    if (!s || !s->initialized || !s->closing || !leaf) return DUCKVEP_CARRIERS_INVALID_ARG;
+    while (s->next_leaf) {
+        uint32_t id = s->next_leaf;
+        const duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[id - 1u];
+        s->next_leaf = prefix->next_transcript;
+        if (!prefix->call_count) continue;
+        *leaf = (duckvep_carrier_leaf_t){id,
+            s->buffers.transcripts[s->closing - 1u].transcript_index,
+            prefix->depth, prefix->first_call, prefix->call_count};
+        return DUCKVEP_CARRIERS_OK;
+    }
+    s->drained = 1u;
+    return DUCKVEP_CARRIERS_DONE;
+}
+
+duckvep_carriers_status_t duckvep_carriers_leaf_events(
+    const duckvep_carriers_t *s, uint32_t id, uint64_t *events,
+    size_t capacity, size_t *required) {
+    if (required) *required = 0u;
+    if (!s || !s->initialized || !s->closing || !required || !id ||
+        id > s->buffers.prefix_capacity || (capacity && !events)) return DUCKVEP_CARRIERS_INVALID_ARG;
+    const duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[id - 1u];
+    if (prefix->transcript != s->closing || !prefix->call_count) return DUCKVEP_CARRIERS_INVALID_ARG;
+    *required = prefix->depth;
+    if (capacity < *required) return DUCKVEP_CARRIERS_OUTPUT_FULL;
+    size_t at = *required;
+    while (id) {
+        prefix = &s->buffers.prefixes[id - 1u];
+        events[--at] = prefix->event_id;
+        id = prefix->parent;
+    }
+    return DUCKVEP_CARRIERS_OK;
+}
+
+const duckvep_carrier_call_t *duckvep_carriers_call(const duckvep_carriers_t *s, uint32_t id) {
+    if (!s || !s->initialized || !s->closing || !id || id > s->buffers.call_capacity) return NULL;
+    const duckvep_carrier_call_t *call = &s->buffers.calls[id - 1u];
+    return call->transcript == s->closing ? call : NULL;
+}
+
+duckvep_carriers_status_t duckvep_carriers_release(duckvep_carriers_t *s) {
+    if (!s || !s->initialized || !s->closing || !s->drained) return DUCKVEP_CARRIERS_INVALID_ARG;
+    uint32_t tx_id = s->closing;
+    duckvep_carrier_transcript_t *tx = &s->buffers.transcripts[tx_id - 1u];
+    uint32_t id = tx->first_call, at;
+    while (id) {
+        duckvep_carrier_call_t *call = &s->buffers.calls[id - 1u];
+        uint32_t next = call->next_transcript;
+        (void)find_call(s, tx_id, &call->key, &at);
+        remove_bucket(s->buffers.call_index, s->buffers.call_buckets, at);
+        call->transcript = 0u;
+        call->next_free = s->free_call;
+        s->free_call = id;
+        s->call_count--;
+        id = next;
+    }
+    id = tx->first_prefix;
+    while (id) {
+        duckvep_carrier_prefix_t *prefix = &s->buffers.prefixes[id - 1u];
+        uint32_t next = prefix->next_transcript;
+        (void)find_prefix(s, tx_id, prefix->parent, prefix->event_id, &at);
+        remove_bucket(s->buffers.prefix_index, s->buffers.prefix_buckets, at);
+        prefix->transcript = 0u;
+        prefix->next_free = s->free_prefix;
+        s->free_prefix = id;
+        s->prefix_count--;
+        id = next;
+    }
+    (void)find_transcript(s, tx->transcript_index, &at);
+    remove_bucket(s->buffers.transcript_index, s->buffers.transcript_buckets, at);
+    uint32_t last = s->buffers.active_transcripts[--s->transcript_count];
+    s->buffers.active_transcripts[tx->active_pos] = last;
+    s->buffers.transcripts[last - 1u].active_pos = tx->active_pos;
+    tx->next_free = s->free_transcript;
+    s->free_transcript = tx_id;
+    s->closing = 0u;
+    s->drained = 0u;
+    return DUCKVEP_CARRIERS_OK;
+}

--- a/src/duckvep/kernel/src/duckvep_carriers.h
+++ b/src/duckvep/kernel/src/duckvep_carriers.h
@@ -1,0 +1,129 @@
+/* Sparse, model-scoped carrier paths over projected event identities (INTERNAL).
+ * No allocation, DuckDB, HTSlib, phase-policy inference or allele decoding.
+ *
+ * The owner pins one immutable transcript model and owns all buffers. Projected
+ * alleles/provenance stay in its event store until a transcript is drained.
+ * This index stores only event IDs: identical prefixes share nodes across
+ * samples/phase sets/lanes; reference paths require no entry. Input is ordered
+ * by (chrom_id, pos1, event_id), with a unique event ID per source event. Calls
+ * for one event may span arbitrarily many input batches.
+ *
+ * advance/finish report a completed transcript before accepting further input.
+ * Drain its distinct leaves, materialize each leaf and its carrier list, then
+ * release it. All returned IDs/views expire at release. Releasing returns the
+ * transcript's slots to the pools; memory does not grow with past transcripts.
+ */
+#ifndef DUCKVEP_CARRIERS_H
+#define DUCKVEP_CARRIERS_H
+
+#include "duckvep_kernel.h"
+
+typedef enum {
+    DUCKVEP_CARRIERS_OK,
+    DUCKVEP_CARRIERS_TRANSCRIPT_READY,
+    DUCKVEP_CARRIERS_DONE,
+    DUCKVEP_CARRIERS_INVALID_ARG,
+    DUCKVEP_CARRIERS_INPUT_ORDER,
+    DUCKVEP_CARRIERS_TRANSCRIPT_FULL,
+    DUCKVEP_CARRIERS_CALL_FULL,
+    DUCKVEP_CARRIERS_PREFIX_FULL,
+    DUCKVEP_CARRIERS_OUTPUT_FULL,
+    DUCKVEP_CARRIERS_DUPLICATE_CALL,
+    DUCKVEP_CARRIERS_PLOIDY_CONFLICT
+} duckvep_carriers_status_t;
+
+typedef struct {
+    uint32_t sample_index;
+    int64_t phase_set;
+    uint16_t lane;                  /* One-based, at most ploidy. */
+    uint16_t ploidy;
+    uint8_t phase_set_present;      /* Absent and a present PS=0 are distinct. */
+} duckvep_carrier_key_t;
+
+/* Slots and hash buckets are caller-owned implementation storage. A zero ID
+ * means no slot; live IDs are one-based offsets into their respective arrays. */
+typedef struct {
+    uint64_t hash;
+    uint32_t id;
+} duckvep_carrier_bucket_t;
+
+typedef struct {
+    uint32_t transcript_index, active_pos;
+    uint32_t first_call, first_prefix, next_free;
+} duckvep_carrier_transcript_t;
+
+typedef struct {
+    duckvep_carrier_key_t key;
+    uint32_t transcript, leaf, next_transcript, next_leaf, previous_leaf, next_free;
+} duckvep_carrier_call_t;
+
+typedef struct {
+    uint64_t event_id;
+    uint32_t transcript, parent, depth, first_call, call_count, next_transcript, next_free;
+} duckvep_carrier_prefix_t;
+
+typedef struct {
+    duckvep_carrier_transcript_t *transcripts;
+    duckvep_carrier_call_t *calls;
+    duckvep_carrier_prefix_t *prefixes;
+    uint32_t *active_transcripts;
+    duckvep_carrier_bucket_t *transcript_index, *call_index, *prefix_index;
+    uint32_t transcript_capacity, call_capacity, prefix_capacity;
+    uint32_t transcript_buckets, call_buckets, prefix_buckets;
+} duckvep_carrier_buffers_t;
+
+typedef struct {
+    const duckvep_transcript_model_t *model;
+    duckvep_carrier_buffers_t buffers;
+    uint32_t free_transcript, free_call, free_prefix;
+    uint32_t transcript_count, call_count, prefix_count;
+    uint32_t peak_transcripts, peak_calls, peak_prefixes;
+    uint32_t closing, next_leaf;
+    uint32_t pos1, pending_pos1;
+    uint64_t event_id, pending_event_id;
+    uint16_t chrom, pending_chrom;
+    uint8_t initialized, have_event, pending, pending_eof, finished, drained;
+} duckvep_carriers_t;
+
+typedef struct {
+    uint32_t id, transcript_index, event_count, first_call, call_count;
+} duckvep_carrier_leaf_t;
+
+/* Buffer arrays must be distinct. Each hash size is a power of two at least
+ * twice its pool capacity, or both sizes are zero. Init clears all storage. */
+duckvep_carriers_status_t duckvep_carriers_init(
+    duckvep_carriers_t *stream, const duckvep_transcript_model_t *model,
+    const duckvep_carrier_buffers_t *buffers);
+
+/* Retry the same tuple after draining each TRANSCRIPT_READY. The completed
+ * model-local ordinal is written to transcript_index. Equal tuples continue
+ * the same event across batches; decreasing tuples fail without mutation. */
+duckvep_carriers_status_t duckvep_carriers_advance(
+    duckvep_carriers_t *stream, uint16_t chrom, uint32_t pos1, uint64_t event_id,
+    uint32_t *transcript_index);
+duckvep_carriers_status_t duckvep_carriers_finish(
+    duckvep_carriers_t *stream, uint32_t *transcript_index);
+
+/* Append the current non-reference event to one carrier. Capacity failures,
+ * duplicate calls and changed ploidy for an existing carrier key leave all
+ * path/pool state unchanged.
+ * Phase interpretation belongs to the consumer; this preserves explicit keys. */
+duckvep_carriers_status_t duckvep_carriers_push(
+    duckvep_carriers_t *stream, uint32_t transcript_index,
+    const duckvep_carrier_key_t *key);
+
+/* Each distinct occupied prefix is emitted once, including a prefix that is
+ * both a completed carrier path and an ancestor of a longer carrier path. */
+duckvep_carriers_status_t duckvep_carriers_next_leaf(
+    duckvep_carriers_t *stream, duckvep_carrier_leaf_t *leaf);
+/* Event IDs are returned in arrival order. No output is written on OUTPUT_FULL. */
+duckvep_carriers_status_t duckvep_carriers_leaf_events(
+    const duckvep_carriers_t *stream, uint32_t leaf, uint64_t *events,
+    size_t capacity, size_t *required);
+/* Iterate from leaf.first_call through next_leaf. Borrowed until release. */
+const duckvep_carrier_call_t *duckvep_carriers_call(
+    const duckvep_carriers_t *stream, uint32_t call);
+/* Requires next_leaf to have returned DONE. No other transcript is released. */
+duckvep_carriers_status_t duckvep_carriers_release(duckvep_carriers_t *stream);
+
+#endif

--- a/src/duckvep/kernel/src/duckvep_carriers.h
+++ b/src/duckvep/kernel/src/duckvep_carriers.h
@@ -48,7 +48,7 @@ typedef struct {
 } duckvep_carrier_bucket_t;
 
 typedef struct {
-    uint32_t transcript_index, active_pos;
+    uint32_t transcript_index;
     uint32_t first_call, first_prefix, next_free;
 } duckvep_carrier_transcript_t;
 
@@ -66,7 +66,7 @@ typedef struct {
     duckvep_carrier_transcript_t *transcripts;
     duckvep_carrier_call_t *calls;
     duckvep_carrier_prefix_t *prefixes;
-    uint32_t *active_transcripts;
+    uint32_t *active_transcripts;   /* Min-heap by model chromosome, end, ordinal. */
     duckvep_carrier_bucket_t *transcript_index, *call_index, *prefix_index;
     uint32_t transcript_capacity, call_capacity, prefix_capacity;
     uint32_t transcript_buckets, call_buckets, prefix_buckets;

--- a/test/duckvep/conformance/README.md
+++ b/test/duckvep/conformance/README.md
@@ -508,8 +508,14 @@ every CDS contributor, per-sample counts and total carrier counts. For a larger 
 make test-duckvep-haplotype-mechanics DUCKVEP_HAPLOTYPE_ARGS="--cases 1000 --seed 173"
 ```
 
-The R driver supplies known original-CDS coordinates to a test-only `.C` bridge;
-Haplosaurus independently parses and projects the same genomic alleles. The Perl observer
+The R driver supplies known original-CDS coordinates to test-only `.C` bridges.
+One applies each independently grouped edit set; the other feeds explicit carrier rows
+through the native sparse prefix index, resumes between every carrier row, and rebuilds
+and translates each occupied event path once. Their complete lane outputs must agree
+before comparison with Haplosaurus. `carrier_metrics.csv` records input events/carriers,
+peak active slots, completed event paths and translated bases; it is diagnostic work
+accounting, not an execution-time or cohort-memory benchmark. Haplosaurus independently
+parses and projects the same genomic alleles. The Perl observer
 changes only serialization. Clean exact-commit VEP/Variation mirrors and the existing
 exact-package environment lock are required. Generated inputs, both engines' complete
 observations, mismatch rows, counts and byte receipts remain in a unique directory under
@@ -519,7 +525,7 @@ Seven deliberate corruptions exercise each comparison field; their rejection cou
 are reported separately from the real engine comparisons.
 
 This is **not** a public phased-executor certificate: it does not test DuckDB carrier
-streaming, strict phase/PS grouping, sparse-prefix ownership, compound SO/HGVS, structural
+streaming, strict phase/PS interpretation, compound SO/HGVS, structural
 composition or arbitrary ploidy. Haplosaurus exposes sequence differences and frame
 flags, not a compound SO/HGVS oracle. Its offline container also defaults to two lanes
 without inferring VCF ploidy; that behavior must not silently define DuckVEP's ploidy

--- a/test/duckvep/conformance/haplotype_differential.R
+++ b/test/duckvep/conformance/haplotype_differential.R
@@ -101,6 +101,7 @@ main <- function() {
     c(
       "test/duckvep/conformance/haplotype_probe.c",
       "src/duckvep/kernel/src/duckvep_haplotype.c",
+      "src/duckvep/kernel/src/duckvep_carriers.c",
       "src/duckvep/kernel/src/duckvep_codon.c"
     )
   )
@@ -118,6 +119,8 @@ main <- function() {
         "-shared",
         "-I",
         shQuote(file.path(root, "src/duckvep/kernel/src")),
+        "-I",
+        shQuote(file.path(root, "src/duckvep/kernel/include")),
         shQuote(sources),
         "-o",
         shQuote(shared)
@@ -130,6 +133,10 @@ main <- function() {
   dll <- dyn.load(shared)
   on.exit(dyn.unload(shared), add = TRUE)
   symbol <- getNativeSymbolInfo("duckhts_test_haplotype", PACKAGE = dll)
+  carrier_symbol <- getNativeSymbolInfo(
+    "duckhts_test_carrier_haplotypes",
+    PACKAGE = dll
+  )
   reverse_complement <- function(x) {
     paste(rev(strsplit(chartr("ACGT", "TGCA", x), "")[[1L]]), collapse = "")
   }
@@ -314,6 +321,7 @@ main <- function() {
       shape = shape,
       strand = strand,
       cds = cds,
+      positions = variants$pos,
       edits = edits
     )
   }
@@ -418,6 +426,77 @@ main <- function() {
       contributors = sort(edits$id)
     )
   }
+  stream_edits <- function(case) {
+    edits <- case$edits
+    n <- nrow(edits)
+    capacity <- nchar(case$cds) + sum(nchar(edits$alt)) + 1L
+    lanes <- rbind(
+      rep(1L, n),
+      1L + as.integer(seq_len(n) %% 2L == 0L),
+      rep(1L, n)
+    )
+    answer <- .C(
+      carrier_symbol,
+      charToRaw(case$cds),
+      as.integer(nchar(case$cds)),
+      case$strand,
+      as.integer(case$positions),
+      as.integer(edits$start),
+      edits$ref,
+      edits$alt,
+      as.integer(n),
+      as.integer(order(case$positions, seq_len(n)) - 1L),
+      as.integer(lanes),
+      as.integer(capacity),
+      cds = raw(6L * capacity),
+      protein = raw(6L * capacity),
+      cds_lengths = integer(6L),
+      protein_lengths = integer(6L),
+      flags = integer(6L),
+      contributors = integer(6L * n),
+      contributor_counts = integer(6L),
+      metrics = double(6L),
+      status = integer(1L)
+    )
+    if (answer$status != 0L) {
+      saveRDS(
+        list(input = case, output = answer),
+        file.path(out, "carrier_failure.rds")
+      )
+      stop("carrier index failed for ", case$transcript, ": ", answer$status)
+    }
+    paths <- lapply(seq_len(6L), function(slot) {
+      offset <- (slot - 1L) * capacity
+      contributors <- answer$contributors[
+        (slot - 1L) * n + seq_len(answer$contributor_counts[slot])
+      ]
+      list(
+        cds = rawToChar(answer$cds[offset + seq_len(answer$cds_lengths[slot])]),
+        protein = rawToChar(answer$protein[
+          offset + seq_len(answer$protein_lengths[slot])
+        ]),
+        flags = sort(c("indel", "frameshift", "resolved_frameshift")[
+          bitwAnd(answer$flags[slot], c(1L, 2L, 4L)) != 0L
+        ]),
+        contributors = sort(edits$id[contributors + 1L]),
+        sample = rep(c("cis", "trans", "shared"), each = 2L)[slot]
+      )
+    })
+    list(
+      paths = paths,
+      metrics = data.frame(
+        transcript = case$transcript,
+        input_events = n,
+        input_carriers = 3L * n,
+        peak_transcripts = answer$metrics[1L],
+        peak_calls = answer$metrics[2L],
+        peak_prefixes = answer$metrics[3L],
+        completed_event_paths = answer$metrics[4L],
+        translated_bases = answer$metrics[5L],
+        completed_carriers = answer$metrics[6L]
+      )
+    )
+  }
   compare_haplotypes <- function(expected, oracle) {
     groups <- split(expected, vapply(expected, `[[`, "", "cds"))
     checks <- logical()
@@ -476,6 +555,7 @@ main <- function() {
   failures <- list()
   comparisons <- 0L
   native <- vector("list", length(cases))
+  carrier_metrics <- vector("list", length(cases))
   names(native) <- vapply(cases, `[[`, "", "transcript")
   for (case in cases) {
     expected <- list()
@@ -491,8 +571,20 @@ main <- function() {
         expected[[length(expected) + 1L]] <- haplotype
       }
     }
-    native[[case$transcript]] <- expected
-    checks <- compare_haplotypes(expected, observed[[case$transcript]])
+    streamed <- stream_edits(case)
+    if (!identical(expected, streamed$paths)) {
+      saveRDS(
+        list(input = case, direct = expected, streamed = streamed),
+        file.path(out, "carrier_failure.rds")
+      )
+      stop(
+        "carrier index disagrees with direct edit sets for ",
+        case$transcript
+      )
+    }
+    native[[case$transcript]] <- streamed$paths
+    carrier_metrics[[match(case$transcript, names(native))]] <- streamed$metrics
+    checks <- compare_haplotypes(streamed$paths, observed[[case$transcript]])
     comparisons <- comparisons + length(checks)
     if (any(!checks)) {
       failures[[length(failures) + 1L]] <- data.frame(
@@ -514,6 +606,11 @@ main <- function() {
     )
   }
   saveRDS(native, file.path(out, "native.rds"))
+  write.csv(
+    do.call(rbind, carrier_metrics),
+    file.path(out, "carrier_metrics.csv"),
+    row.names = FALSE
+  )
   write.csv(failures, file.path(out, "failures.csv"), row.names = FALSE)
   # Exercise every comparison axis with a deliberate corruption. These seven
   # verifier controls are separate from the engine-comparison denominators.
@@ -586,6 +683,8 @@ main <- function() {
       c(
         "scripts/duckvep_evidence.R",
         "src/duckvep/kernel/src/duckvep_haplotype.h",
+        "src/duckvep/kernel/src/duckvep_carriers.h",
+        "src/duckvep/kernel/include/duckvep_kernel.h",
         "src/duckvep/kernel/src/duckvep_codon.h",
         "src/duckvep/kernel/src/duckvep_dna.h"
       )
@@ -601,6 +700,7 @@ main <- function() {
         "carriers.vcf",
         "inputs.rds",
         "native.rds",
+        "carrier_metrics.csv",
         "oracle.jsonl",
         "summary.csv",
         "failures.csv",
@@ -613,7 +713,7 @@ main <- function() {
   hashes <- vapply(identities, duckvep_evidence_sha256, "")
   jsonlite::write_json(
     list(
-      scope = "diploid_edit_set_mechanics_not_public_phased_execution",
+      scope = "diploid_carrier_prefix_and_edit_mechanics_not_public_phased_execution",
       source_revision = system2("git", c("rev-parse", "HEAD"), stdout = TRUE),
       dirty_worktree = length(system2(
         "git",

--- a/test/duckvep/conformance/haplotype_probe.c
+++ b/test/duckvep/conformance/haplotype_probe.c
@@ -1,7 +1,8 @@
-/* Test-only R .C bridge to the unmodified, host-neutral mutation kernel.
- * R owns every input/output buffer; this bridge owns only edit descriptors.
- * This is not a SQL adapter or an implementation of carrier stream grouping. */
+/* Test-only R .C bridges to the host-neutral mutation and carrier-path kernels.
+ * R owns every input/output buffer; the bridges own bounded test scratch.
+ * These are not SQL adapters and do not decode GT or choose a phase policy. */
 #include "duckvep_haplotype.h"
+#include "duckvep_carriers.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
@@ -50,4 +51,154 @@ void duckhts_test_haplotype(
     *flags = (int)(applied.flags | translated.flags);
 cleanup:
     free(edits);
+}
+
+static int descending_edit(const void *a, const void *b) {
+    uint32_t x = ((const duckvep_haplotype_edit_t *)a)->cds_start;
+    uint32_t y = ((const duckvep_haplotype_edit_t *)b)->cds_start;
+    return x < y ? 1 : x > y ? -1 : 0;
+}
+
+/* Exercise the real sparse index with the same three diploid fixture samples.
+ * R supplies the allele-slot assignments that generated the VCF, not grouped
+ * haplotypes. The bridge owns bounded test scratch and adapts each distinct
+ * completed event path to the existing mutation/translation kernel once.
+ * No genomic projection or phase-policy inference is implemented here. */
+void duckhts_test_carrier_haplotypes(
+    uint8_t *reference, int *reference_length, int *strand, int *positions,
+    int *starts, char **refs, char **alts, int *edit_count, int *order, int *lanes,
+    int *capacity, uint8_t *cds, uint8_t *protein, int *cds_lengths,
+    int *protein_lengths, int *flags, int *contributors, int *contributor_counts,
+    double *metrics, int *status) {
+    duckvep_carrier_buffers_t b = {0};
+    duckvep_carriers_t stream;
+    duckvep_haplotype_edit_t *all_edits = NULL, *leaf_edits = NULL;
+    uint64_t *events = NULL;
+    uint8_t *cds_scratch = NULL, *protein_scratch = NULL;
+    uint16_t chrom = 0u;
+    uint32_t end1 = UINT32_MAX, completed, active;
+    duckvep_transcript_model_t model = {0};
+    duckvep_carrier_transcript_t transcript;
+    duckvep_carrier_bucket_t transcript_index[2];
+    duckvep_carriers_status_t stream_status;
+    *status = DUCKVEP_HAPLOTYPE_INVALID_ARG;
+    memset(metrics, 0, 6u * sizeof(*metrics));
+    if (*reference_length < 0 || *edit_count < 1 || *edit_count > 1000000 ||
+        *capacity < 1 || *capacity > INT_MAX / 6 || (*strand != -1 && *strand != 1)) return;
+    size_t count = (size_t)*edit_count;
+    all_edits = calloc(count, sizeof(*all_edits));
+    leaf_edits = calloc(count, sizeof(*leaf_edits));
+    events = calloc(count, sizeof(*events));
+    cds_scratch = malloc((size_t)*capacity);
+    protein_scratch = malloc((size_t)*capacity);
+    b.transcripts = &transcript;
+    b.active_transcripts = &active;
+    b.transcript_index = transcript_index;
+    b.transcript_capacity = 1u; b.transcript_buckets = 2u;
+    b.call_capacity = 6u; b.call_buckets = 16u;
+    b.prefix_capacity = 3u * (uint32_t)count;
+    b.prefix_buckets = 1u;
+    while (b.prefix_buckets < 2u * b.prefix_capacity) b.prefix_buckets *= 2u;
+    b.calls = calloc(b.call_capacity, sizeof(*b.calls));
+    b.call_index = calloc(b.call_buckets, sizeof(*b.call_index));
+    b.prefixes = calloc(b.prefix_capacity, sizeof(*b.prefixes));
+    b.prefix_index = calloc(b.prefix_buckets, sizeof(*b.prefix_index));
+    if (!all_edits || !leaf_edits || !events || !cds_scratch || !protein_scratch ||
+        !b.calls || !b.call_index || !b.prefixes || !b.prefix_index) goto cleanup;
+    for (size_t i = 0u; i < count; i++) {
+        size_t ref_len = strlen(refs[i]), alt_len = strlen(alts[i]);
+        if (starts[i] < 1 || positions[i] < 1 || ref_len > UINT32_MAX || alt_len > UINT32_MAX ||
+            order[i] < 0 || (size_t)order[i] >= count) goto cleanup;
+        all_edits[i] = (duckvep_haplotype_edit_t){(uint32_t)starts[i], (uint32_t)ref_len,
+            (const uint8_t *)refs[i], (uint32_t)alt_len, (const uint8_t *)alts[i], 1};
+    }
+    model.transcript_count = 1u; model.chrom_id = &chrom; model.end1 = &end1;
+    stream_status = duckvep_carriers_init(&stream, &model, &b);
+    if (stream_status != DUCKVEP_CARRIERS_OK) goto stream_error;
+    for (size_t i = 0u; i < count; i++) {
+        size_t event = (size_t)order[i];
+        for (uint32_t sample = 0u; sample < 3u; sample++) {
+            /* Resume even between carriers of the same input event, simulating
+             * a source batch ending at every possible carrier row. */
+            stream_status = duckvep_carriers_advance(&stream, 0u,
+                (uint32_t)positions[event], event + 1u, &completed);
+            if (stream_status != DUCKVEP_CARRIERS_OK) goto stream_error;
+            int lane = lanes[event * 3u + sample];
+            if (lane < 1 || lane > 2) goto cleanup;
+            duckvep_carrier_key_t key = {sample, 10, (uint16_t)lane, 2u, 1u};
+            stream_status = duckvep_carriers_push(&stream, 0u, &key);
+            if (stream_status != DUCKVEP_CARRIERS_OK) goto stream_error;
+        }
+    }
+    /* Reference lanes are implicit in the sparse index. The fixture adapter
+     * materializes them from one shared reference translation for comparison
+     * with Haplosaurus, which reports all six lanes. */
+    size_t cds_len, protein_len;
+    duckvep_haplotype_result_t applied, translated;
+    *status = duckvep_haplotype_apply_cds_edits(reference, (size_t)*reference_length,
+        NULL, 0u, (int8_t)*strand, cds_scratch, (size_t)*capacity, &cds_len, &applied);
+    if (*status != DUCKVEP_HAPLOTYPE_OK) goto cleanup;
+    *status = duckvep_haplotype_translate_cds(cds_scratch, cds_len, DUCKVEP_CODON_TABLE_STANDARD,
+        protein_scratch, (size_t)*capacity, &protein_len, &translated);
+    if (*status != DUCKVEP_HAPLOTYPE_OK) goto cleanup;
+    for (size_t slot = 0u; slot < 6u; slot++) {
+        memcpy(cds + slot * (size_t)*capacity, cds_scratch, cds_len);
+        memcpy(protein + slot * (size_t)*capacity, protein_scratch, protein_len);
+        cds_lengths[slot] = (int)cds_len; protein_lengths[slot] = (int)protein_len;
+        flags[slot] = (int)(applied.flags | translated.flags);
+        contributor_counts[slot] = 0;
+    }
+    stream_status = duckvep_carriers_finish(&stream, &completed);
+    if (stream_status != DUCKVEP_CARRIERS_TRANSCRIPT_READY) goto stream_error;
+    duckvep_carrier_leaf_t leaf;
+    while ((stream_status = duckvep_carriers_next_leaf(&stream, &leaf)) == DUCKVEP_CARRIERS_OK) {
+        size_t required;
+        stream_status = duckvep_carriers_leaf_events(&stream, leaf.id, events, count, &required);
+        if (stream_status != DUCKVEP_CARRIERS_OK) goto stream_error;
+        for (size_t i = 0u; i < required; i++) {
+            if (!events[i] || events[i] > count) goto invalid;
+            leaf_edits[i] = all_edits[events[i] - 1u];
+        }
+        qsort(leaf_edits, required, sizeof(*leaf_edits), descending_edit);
+        *status = duckvep_haplotype_apply_cds_edits(reference, (size_t)*reference_length,
+            leaf_edits, required, (int8_t)*strand, cds_scratch, (size_t)*capacity, &cds_len, &applied);
+        if (*status != DUCKVEP_HAPLOTYPE_OK) goto cleanup;
+        *status = duckvep_haplotype_translate_cds(cds_scratch, cds_len, DUCKVEP_CODON_TABLE_STANDARD,
+            protein_scratch, (size_t)*capacity, &protein_len, &translated);
+        if (*status != DUCKVEP_HAPLOTYPE_OK) goto cleanup;
+        metrics[3] += 1.0;
+        metrics[4] += (double)cds_len;
+        for (uint32_t id = leaf.first_call; id;) {
+            const duckvep_carrier_call_t *call = duckvep_carriers_call(&stream, id);
+            if (!call || call->key.sample_index >= 3u || call->key.lane > 2u) goto invalid;
+            size_t slot = (size_t)call->key.sample_index * 2u + call->key.lane - 1u;
+            memcpy(cds + slot * (size_t)*capacity, cds_scratch, cds_len);
+            memcpy(protein + slot * (size_t)*capacity, protein_scratch, protein_len);
+            cds_lengths[slot] = (int)cds_len; protein_lengths[slot] = (int)protein_len;
+            flags[slot] = (int)(applied.flags | translated.flags);
+            contributor_counts[slot] = (int)required;
+            for (size_t i = 0u; i < required; i++) contributors[slot * count + i] = (int)events[i] - 1;
+            metrics[5] += 1.0;
+            id = call->next_leaf;
+        }
+    }
+    if (stream_status != DUCKVEP_CARRIERS_DONE) goto stream_error;
+    stream_status = duckvep_carriers_release(&stream);
+    if (stream_status != DUCKVEP_CARRIERS_OK) goto stream_error;
+    stream_status = duckvep_carriers_finish(&stream, &completed);
+    if (stream_status != DUCKVEP_CARRIERS_DONE) goto stream_error;
+    metrics[0] = stream.peak_transcripts;
+    metrics[1] = stream.peak_calls;
+    metrics[2] = stream.peak_prefixes;
+    *status = DUCKVEP_HAPLOTYPE_OK;
+    goto cleanup;
+invalid:
+    *status = DUCKVEP_HAPLOTYPE_INVALID_ARG;
+    goto cleanup;
+stream_error:
+    *status = 100 + (int)stream_status;
+cleanup:
+    free(all_edits); free(leaf_edits); free(events);
+    free(cds_scratch); free(protein_scratch);
+    free(b.calls); free(b.call_index); free(b.prefixes); free(b.prefix_index);
 }

--- a/test/duckvep/property/duckvep_kernel_prop.c
+++ b/test/duckvep/property/duckvep_kernel_prop.c
@@ -8726,6 +8726,90 @@ TEST carrier_stream_reuses_slots_after_many_transcripts(void) {
     PASS();
 }
 
+TEST carrier_stream_expiry_heap_matches_dense_active_set(void) {
+    enum { TRANSCRIPTS = 256, SLOTS = 64 };
+    uint16_t chrom[TRANSCRIPTS] = {0};
+    uint32_t end[TRANSCRIPTS], start[TRANSCRIPTS], active[SLOTS];
+    uint8_t live[TRANSCRIPTS] = {0};
+    duckvep_carrier_transcript_t transcripts[SLOTS];
+    duckvep_carrier_call_t calls[SLOTS];
+    duckvep_carrier_prefix_t prefixes[SLOTS];
+    duckvep_carrier_bucket_t tx_index[2 * SLOTS], call_index[2 * SLOTS], prefix_index[2 * SLOTS];
+    duckvep_carrier_buffers_t b = {transcripts, calls, prefixes, active,
+        tx_index, call_index, prefix_index, SLOTS, SLOTS, SLOTS,
+        2 * SLOTS, 2 * SLOTS, 2 * SLOTS};
+    /* Model ordinals are not opening order. First fill every slot with tied
+     * ends; then interleave openings and expiry with up to 64 live positions. */
+    for (uint32_t pos = 1u; pos <= TRANSCRIPTS; pos++) {
+        uint32_t tx = (pos * 73u) % TRANSCRIPTS;
+        start[tx] = pos;
+        end[tx] = pos <= SLOTS ? SLOTS : pos + (tx * 29u) % SLOTS;
+    }
+    duckvep_transcript_model_t model = {0};
+    model.transcript_count = TRANSCRIPTS; model.chrom_id = chrom; model.end1 = end;
+    duckvep_carriers_t s;
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_init(&s, &model, &b));
+    uint32_t drained = 0u;
+    for (uint32_t pos = 1u; pos <= TRANSCRIPTS + 1u; pos++) {
+        int eof = pos > TRANSCRIPTS;
+        for (;;) {
+            uint32_t expected = UINT32_MAX, completed;
+            for (uint32_t tx = 0u; tx < TRANSCRIPTS; tx++) {
+                if (live[tx] && (expected == UINT32_MAX || end[tx] < end[expected])) expected = tx;
+            }
+            duckvep_carriers_status_t status = eof ? duckvep_carriers_finish(&s, &completed)
+                : duckvep_carriers_advance(&s, 0u, pos, pos, &completed);
+            if (expected == UINT32_MAX || (!eof && end[expected] >= pos)) {
+                ASSERT_EQ(eof ? DUCKVEP_CARRIERS_DONE : DUCKVEP_CARRIERS_OK, status);
+                break;
+            }
+            ASSERT_EQ(DUCKVEP_CARRIERS_TRANSCRIPT_READY, status);
+            ASSERT_EQ(expected, completed);
+            duckvep_carrier_leaf_t leaf;
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_next_leaf(&s, &leaf));
+            ASSERT_EQ(expected, leaf.transcript_index);
+            ASSERT_EQ(1u, leaf.call_count);
+            uint64_t event;
+            size_t required;
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK,
+                      duckvep_carriers_leaf_events(&s, leaf.id, &event, 1u, &required));
+            ASSERT_EQ(1u, required); ASSERT_EQ(start[expected], event);
+            const duckvep_carrier_call_t *call = duckvep_carriers_call(&s, leaf.first_call);
+            ASSERT(call != NULL); ASSERT_EQ(expected, call->key.sample_index);
+            ASSERT_EQ(0u, call->next_leaf);
+            ASSERT_EQ(DUCKVEP_CARRIERS_DONE, duckvep_carriers_next_leaf(&s, &leaf));
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_release(&s));
+            live[expected] = 0u;
+            drained++;
+        }
+        if (!eof) {
+            uint32_t tx = (pos * 73u) % TRANSCRIPTS, completed;
+            duckvep_carrier_key_t key = carrier_test_key(tx);
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_push(&s, tx, &key));
+            live[tx] = 1u;
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 0u, pos, pos, &completed));
+        }
+        uint32_t live_count = 0u, earliest = UINT32_MAX;
+        for (uint32_t tx = 0u; tx < TRANSCRIPTS; tx++) if (live[tx]) {
+            live_count++;
+            if (earliest == UINT32_MAX || end[tx] < end[earliest]) earliest = tx;
+        }
+        ASSERT_EQ(live_count, s.transcript_count);
+        ASSERT_EQ(live_count, s.call_count); ASSERT_EQ(live_count, s.prefix_count);
+        if (live_count) {
+            ASSERT_EQ(earliest, transcripts[active[0] - 1u].transcript_index);
+            for (uint32_t child = 1u; child < live_count; child++) {
+                uint32_t a = transcripts[active[(child - 1u) / 2u] - 1u].transcript_index;
+                uint32_t z = transcripts[active[child] - 1u].transcript_index;
+                ASSERT(end[a] < end[z] || (end[a] == end[z] && a < z));
+            }
+        }
+    }
+    ASSERT_EQ(TRANSCRIPTS, drained);
+    ASSERT_EQ(SLOTS, s.peak_transcripts); ASSERT_EQ(SLOTS, s.peak_calls); ASSERT_EQ(SLOTS, s.peak_prefixes);
+    PASS();
+}
+
 static enum theft_alloc_res carrier_matrix_alloc(struct theft *t, void *env, void **instance) {
     (void)env;
     struct carrier_matrix_case *c = malloc(sizeof(*c));
@@ -25254,6 +25338,7 @@ int main(int argc, char **argv) {
     RUN_TEST(haplotype_edit_geometry_agrees_in_both_orders);
     RUN_TEST(carrier_stream_lifetime_keys_and_capacity);
     RUN_TEST(carrier_stream_reuses_slots_after_many_transcripts);
+    RUN_TEST(carrier_stream_expiry_heap_matches_dense_active_set);
     RUN_TEST(carrier_stream_matches_dense_matrix_across_batches);
     RUN_TEST(haplotype_partition_known_cases);
     RUN_TEST(haplotype_partition_preserves_interactions_for_any_valid_edit_set);

--- a/test/duckvep/property/duckvep_kernel_prop.c
+++ b/test/duckvep/property/duckvep_kernel_prop.c
@@ -26,6 +26,7 @@
 #include "duckvep_codon.h"
 #include "duckvep_coding.h"
 #include "duckvep_haplotype.h"
+#include "duckvep_carriers.h"
 #include "duckvep_annotation_internal.h"
 #include "duckvep_workspace_internal.h"
 
@@ -8487,6 +8488,324 @@ TEST haplotype_edit_geometry_agrees_in_both_orders(void) {
             }
         }
     }
+    PASS();
+}
+
+struct carrier_test_pool {
+    duckvep_carrier_transcript_t transcripts[3];
+    duckvep_carrier_call_t calls[16];
+    duckvep_carrier_prefix_t prefixes[64];
+    uint32_t active[3];
+    duckvep_carrier_bucket_t tx_index[8], call_index[32], prefix_index[128];
+};
+
+static duckvep_carrier_buffers_t carrier_test_buffers(struct carrier_test_pool *pool) {
+    duckvep_carrier_buffers_t b = {pool->transcripts, pool->calls, pool->prefixes,
+        pool->active, pool->tx_index, pool->call_index, pool->prefix_index,
+        3u, 16u, 64u, 8u, 32u, 128u};
+    return b;
+}
+
+static duckvep_carrier_key_t carrier_test_key(uint32_t sample) {
+    duckvep_carrier_key_t key = {sample, sample % 3u == 2u ? -5 : 0,
+        (uint16_t)(sample % 4u + 1u), 4u, (uint8_t)(sample % 3u != 0u)};
+    return key;
+}
+
+/* An independent dense bit matrix is the oracle, not the prefix index. Each
+ * bit names a carried event; the empty mask is an implicit reference path. */
+static int carrier_test_drain(duckvep_carriers_t *s, uint32_t tx,
+                              const uint8_t masks[8], uint64_t event_base) {
+    uint64_t seen_paths = 0u;
+    unsigned seen_samples = 0u;
+    duckvep_carrier_leaf_t leaf;
+    duckvep_carriers_status_t status;
+    while ((status = duckvep_carriers_next_leaf(s, &leaf)) == DUCKVEP_CARRIERS_OK) {
+        uint64_t events[6], before[6];
+        size_t required = 0u;
+        memset(events, 0xa5, sizeof events);
+        memcpy(before, events, sizeof before);
+        if (leaf.transcript_index != tx || !leaf.event_count || !leaf.call_count ||
+            duckvep_carriers_leaf_events(s, leaf.id, events, 0u, &required) !=
+                DUCKVEP_CARRIERS_OUTPUT_FULL || required != leaf.event_count ||
+            memcmp(events, before, sizeof before) != 0 ||
+            duckvep_carriers_leaf_events(s, leaf.id, events, 6u, &required) !=
+                DUCKVEP_CARRIERS_OK) return 0;
+        unsigned mask = 0u;
+        for (size_t i = 0u; i < required; i++) {
+            if (events[i] < event_base || events[i] >= event_base + 6u ||
+                (i && events[i] <= events[i - 1u])) return 0;
+            mask |= 1u << (unsigned)(events[i] - event_base);
+        }
+        if (!mask || (seen_paths & (UINT64_C(1) << mask))) return 0;
+        seen_paths |= UINT64_C(1) << mask;
+        uint32_t count = 0u;
+        for (uint32_t id = leaf.first_call; id;) {
+            const duckvep_carrier_call_t *call = duckvep_carriers_call(s, id);
+            if (!call || ++count > 8u || call->key.sample_index >= 8u) return 0;
+            uint32_t sample = call->key.sample_index;
+            duckvep_carrier_key_t key = carrier_test_key(sample);
+            if ((seen_samples & (1u << sample)) || masks[sample] != mask ||
+                call->key.lane != key.lane || call->key.ploidy != key.ploidy ||
+                call->key.phase_set != key.phase_set ||
+                call->key.phase_set_present != key.phase_set_present) return 0;
+            seen_samples |= 1u << sample;
+            id = call->next_leaf;
+        }
+        if (count != leaf.call_count) return 0;
+    }
+    if (status != DUCKVEP_CARRIERS_DONE) return 0;
+    for (unsigned sample = 0u; sample < 8u; sample++) {
+        if (!!(seen_samples & (1u << sample)) != !!masks[sample]) return 0;
+    }
+    return duckvep_carriers_release(s) == DUCKVEP_CARRIERS_OK;
+}
+
+TEST carrier_stream_lifetime_keys_and_capacity(void) {
+    uint16_t chrom[] = {1u, 1u, 2u};
+    uint32_t end[] = {3u, 8u, 4u};
+    duckvep_transcript_model_t model = {0};
+    model.transcript_count = 3u; model.chrom_id = chrom; model.end1 = end;
+    struct carrier_test_pool pool, before_pool;
+    duckvep_carrier_buffers_t b = carrier_test_buffers(&pool);
+    duckvep_carriers_t s, before;
+    uint32_t completed;
+    duckvep_carrier_key_t key = carrier_test_key(0u);
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_init(&s, &model, &b));
+    ASSERT_EQ(DUCKVEP_CARRIERS_INVALID_ARG, duckvep_carriers_push(&s, 0u, &key));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 1u, 1u, 10u, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_push(&s, 0u, &key));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_push(&s, 1u, &key));
+    /* NULL PS and an explicitly present zero are different carrier keys. */
+    key.phase_set_present = 1u;
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_push(&s, 0u, &key));
+    ASSERT_EQ(3u, s.call_count);
+    ASSERT_EQ(2u, s.prefix_count);
+    before = s; memcpy(&before_pool, &pool, sizeof pool);
+    ASSERT_EQ(DUCKVEP_CARRIERS_DUPLICATE_CALL, duckvep_carriers_push(&s, 0u, &key));
+    key.ploidy = 2u;
+    ASSERT_EQ(DUCKVEP_CARRIERS_PLOIDY_CONFLICT, duckvep_carriers_push(&s, 0u, &key));
+    ASSERT_EQ(0, memcmp(&before, &s, sizeof s));
+    ASSERT_EQ(0, memcmp(&before_pool, &pool, sizeof pool));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 1u, 3u, 11u, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_TRANSCRIPT_READY,
+              duckvep_carriers_advance(&s, 1u, 4u, 12u, &completed));
+    ASSERT_EQ(0u, completed);
+    ASSERT_EQ(DUCKVEP_CARRIERS_INPUT_ORDER,
+              duckvep_carriers_advance(&s, 1u, 5u, 12u, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_INVALID_ARG, duckvep_carriers_release(&s));
+    duckvep_carrier_leaf_t leaf;
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_next_leaf(&s, &leaf));
+    ASSERT_EQ(2u, leaf.call_count);
+    ASSERT_EQ(DUCKVEP_CARRIERS_DONE, duckvep_carriers_next_leaf(&s, &leaf));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_release(&s));
+    ASSERT_EQ(1u, s.transcript_count); ASSERT_EQ(1u, s.call_count); ASSERT_EQ(1u, s.prefix_count);
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 1u, 4u, 12u, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_INPUT_ORDER,
+              duckvep_carriers_advance(&s, 1u, 4u, 11u, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_TRANSCRIPT_READY,
+              duckvep_carriers_advance(&s, 2u, 1u, 13u, &completed));
+    ASSERT_EQ(1u, completed);
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_next_leaf(&s, &leaf));
+    ASSERT_EQ(DUCKVEP_CARRIERS_DONE, duckvep_carriers_next_leaf(&s, &leaf));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_release(&s));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 2u, 1u, 13u, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_push(&s, 2u, &key));
+    ASSERT_EQ(DUCKVEP_CARRIERS_TRANSCRIPT_READY, duckvep_carriers_finish(&s, &completed));
+    ASSERT_EQ(2u, completed);
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_next_leaf(&s, &leaf));
+    ASSERT_EQ(DUCKVEP_CARRIERS_DONE, duckvep_carriers_next_leaf(&s, &leaf));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_release(&s));
+    ASSERT_EQ(DUCKVEP_CARRIERS_DONE, duckvep_carriers_finish(&s, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_DONE, duckvep_carriers_finish(&s, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_INPUT_ORDER,
+              duckvep_carriers_advance(&s, 2u, 2u, 14u, &completed));
+    ASSERT_EQ(0u, s.transcript_count); ASSERT_EQ(0u, s.call_count); ASSERT_EQ(0u, s.prefix_count);
+
+    b.transcript_capacity = 1u; b.transcript_buckets = 2u;
+    b.call_capacity = 2u; b.call_buckets = 4u;
+    b.prefix_capacity = 2u; b.prefix_buckets = 4u;
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_init(&s, &model, &b));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 1u, 1u, 1u, &completed));
+    for (uint32_t sample = 0u; sample < 2u; sample++) {
+        key = carrier_test_key(sample);
+        ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_push(&s, 0u, &key));
+    }
+    before = s; memcpy(&before_pool, &pool, sizeof pool);
+    key = carrier_test_key(2u);
+    ASSERT_EQ(DUCKVEP_CARRIERS_CALL_FULL, duckvep_carriers_push(&s, 0u, &key));
+    ASSERT_EQ(DUCKVEP_CARRIERS_TRANSCRIPT_FULL, duckvep_carriers_push(&s, 1u, &key));
+    ASSERT_EQ(0, memcmp(&before, &s, sizeof s));
+    ASSERT_EQ(0, memcmp(&before_pool, &pool, sizeof pool));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 1u, 2u, 2u, &completed));
+    for (uint32_t sample = 0u; sample < 2u; sample++) {
+        key = carrier_test_key(sample);
+        ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_push(&s, 0u, &key));
+    }
+    ASSERT_EQ(2u, s.prefix_count); /* Reuse succeeds even when no slot is free. */
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 1u, 3u, 3u, &completed));
+    before = s; memcpy(&before_pool, &pool, sizeof pool);
+    ASSERT_EQ(DUCKVEP_CARRIERS_PREFIX_FULL, duckvep_carriers_push(&s, 0u, &key));
+    ASSERT_EQ(0, memcmp(&before, &s, sizeof s));
+    ASSERT_EQ(0, memcmp(&before_pool, &pool, sizeof pool));
+    b.call_capacity = 0u; b.call_buckets = 0u;
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_init(&s, &model, &b));
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_advance(&s, 1u, 1u, 1u, &completed));
+    ASSERT_EQ(DUCKVEP_CARRIERS_CALL_FULL, duckvep_carriers_push(&s, 0u, &key));
+    ASSERT_EQ(0u, s.transcript_count); ASSERT_EQ(0u, s.prefix_count);
+    b.transcript_buckets = 3u;
+    ASSERT_EQ(DUCKVEP_CARRIERS_INVALID_ARG, duckvep_carriers_init(&s, &model, &b));
+    PASS();
+}
+
+struct carrier_matrix_case { uint8_t masks[2][8]; };
+
+TEST carrier_stream_reuses_slots_after_many_transcripts(void) {
+    enum { TRANSCRIPTS = 1000 };
+    uint16_t chrom[TRANSCRIPTS] = {0};
+    uint32_t end[TRANSCRIPTS];
+    for (unsigned i = 0u; i < TRANSCRIPTS; i++) end[i] = i + 1u;
+    duckvep_transcript_model_t model = {0};
+    model.transcript_count = TRANSCRIPTS; model.chrom_id = chrom; model.end1 = end;
+    struct carrier_test_pool pool;
+    duckvep_carrier_buffers_t b = carrier_test_buffers(&pool);
+    b.transcript_capacity = 1u; b.transcript_buckets = 2u;
+    b.call_capacity = 8u; b.call_buckets = 16u;
+    b.prefix_capacity = 1u; b.prefix_buckets = 2u;
+    duckvep_carriers_t s;
+    ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_init(&s, &model, &b));
+    for (uint32_t tx = 0u; tx <= TRANSCRIPTS; tx++) {
+        uint32_t completed;
+        duckvep_carriers_status_t status = tx == TRANSCRIPTS
+            ? duckvep_carriers_finish(&s, &completed)
+            : duckvep_carriers_advance(&s, 0u, tx + 1u, UINT64_MAX - tx, &completed);
+        if (tx) {
+            ASSERT_EQ(DUCKVEP_CARRIERS_TRANSCRIPT_READY, status);
+            ASSERT_EQ(tx - 1u, completed);
+            duckvep_carrier_leaf_t leaf;
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_next_leaf(&s, &leaf));
+            ASSERT_EQ(8u, leaf.call_count);
+            uint64_t event;
+            size_t required;
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK,
+                      duckvep_carriers_leaf_events(&s, leaf.id, &event, 1u, &required));
+            ASSERT_EQ(1u, required);
+            ASSERT_EQ(UINT64_MAX - (tx - 1u), event);
+            unsigned seen = 0u;
+            for (uint32_t id = leaf.first_call; id;) {
+                const duckvep_carrier_call_t *call = duckvep_carriers_call(&s, id);
+                ASSERT(call != NULL);
+                uint32_t sample = call->key.sample_index - (tx - 1u) * 8u;
+                ASSERT(sample < 8u);
+                ASSERT(!(seen & (1u << sample)));
+                seen |= 1u << sample;
+                ASSERT_EQ(sample == 7u ? UINT16_MAX : sample + 1u, call->key.ploidy);
+                ASSERT_EQ(call->key.ploidy, call->key.lane);
+                id = call->next_leaf;
+            }
+            ASSERT_EQ(255u, seen);
+            ASSERT_EQ(DUCKVEP_CARRIERS_DONE, duckvep_carriers_next_leaf(&s, &leaf));
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_release(&s));
+            ASSERT_EQ(0u, s.transcript_count); ASSERT_EQ(0u, s.call_count); ASSERT_EQ(0u, s.prefix_count);
+            status = tx == TRANSCRIPTS ? duckvep_carriers_finish(&s, &completed)
+                : duckvep_carriers_advance(&s, 0u, tx + 1u, UINT64_MAX - tx, &completed);
+        }
+        if (tx == TRANSCRIPTS) {
+            ASSERT_EQ(DUCKVEP_CARRIERS_DONE, status);
+            break;
+        }
+        ASSERT_EQ(DUCKVEP_CARRIERS_OK, status);
+        for (uint32_t sample = 0u; sample < 8u; sample++) {
+            duckvep_carrier_key_t key = carrier_test_key(tx * 8u + sample);
+            key.ploidy = sample == 7u ? UINT16_MAX : (uint16_t)(sample + 1u);
+            key.lane = key.ploidy;
+            ASSERT_EQ(DUCKVEP_CARRIERS_OK, duckvep_carriers_push(&s, tx, &key));
+        }
+    }
+    ASSERT_EQ(1u, s.peak_transcripts); ASSERT_EQ(8u, s.peak_calls); ASSERT_EQ(1u, s.peak_prefixes);
+    PASS();
+}
+
+static enum theft_alloc_res carrier_matrix_alloc(struct theft *t, void *env, void **instance) {
+    (void)env;
+    struct carrier_matrix_case *c = malloc(sizeof(*c));
+    if (!c) return THEFT_ALLOC_ERROR;
+    for (unsigned tx = 0u; tx < 2u; tx++) for (unsigned sample = 0u; sample < 8u; sample++) {
+        c->masks[tx][sample] = (uint8_t)kprop_bounded(t, tx ? 64u : 16u);
+    }
+    /* Include cohort prefix sharing on every trial, not just by chance. */
+    for (unsigned tx = 0u; tx < 2u; tx++) c->masks[tx][7] = c->masks[tx][0];
+    *instance = c;
+    return THEFT_ALLOC_OK;
+}
+
+static void carrier_matrix_free(void *instance, void *env) {
+    (void)env;
+    free(instance);
+}
+
+static enum theft_trial_res prop_carrier_stream_matches_dense_matrix(struct theft *t, void *arg) {
+    (void)t;
+    const struct carrier_matrix_case *c = arg;
+    uint16_t chrom[2][2] = {{1u, 1u}, {2u, 2u}};
+    uint32_t end[2][2] = {{3u, 6u}, {4u, 6u}};
+    duckvep_transcript_model_t models[2] = {{0}, {0}};
+    uint8_t expected[2][2][8];
+    struct carrier_test_pool pools[2];
+    duckvep_carriers_t streams[2];
+    const uint64_t base = UINT64_MAX - 6u;
+    for (unsigned run = 0u; run < 2u; run++) {
+        models[run].transcript_count = 2u;
+        models[run].chrom_id = chrom[run]; models[run].end1 = end[run];
+        memcpy(expected[run], c->masks, sizeof c->masks);
+        for (unsigned sample = 0u; sample < 8u; sample++) expected[run][0][sample] &= run ? 15u : 7u;
+        duckvep_carrier_buffers_t b = carrier_test_buffers(&pools[run]);
+        if (duckvep_carriers_init(&streams[run], &models[run], &b) != DUCKVEP_CARRIERS_OK)
+            return THEFT_TRIAL_ERROR;
+    }
+    /* Interleave different models with identical local ordinals but different
+     * contigs/transcript endpoints. One also resumes between every carrier row. */
+    for (uint32_t pos = 1u; pos <= 6u; pos++) for (unsigned run = 0u; run < 2u; run++) {
+        duckvep_carriers_t *s = &streams[run];
+        uint32_t tx;
+        duckvep_carriers_status_t status;
+        while ((status = duckvep_carriers_advance(s, (uint16_t)(run + 1u), pos, base + pos - 1u, &tx)) ==
+                   DUCKVEP_CARRIERS_TRANSCRIPT_READY) {
+            if (!carrier_test_drain(s, tx, expected[run][tx], base)) return THEFT_TRIAL_FAIL;
+        }
+        if (status != DUCKVEP_CARRIERS_OK) return THEFT_TRIAL_FAIL;
+        for (tx = 0u; tx < 2u; tx++) for (uint32_t sample = 0u; sample < 8u; sample++) {
+            if (!(expected[run][tx][sample] & (1u << (pos - 1u)))) continue;
+            uint32_t completed;
+            if (run && duckvep_carriers_advance(s, (uint16_t)(run + 1u), pos, base + pos - 1u, &completed) !=
+                           DUCKVEP_CARRIERS_OK) return THEFT_TRIAL_FAIL;
+            duckvep_carrier_key_t key = carrier_test_key(sample);
+            if (duckvep_carriers_push(s, tx, &key) != DUCKVEP_CARRIERS_OK) return THEFT_TRIAL_FAIL;
+        }
+    }
+    for (unsigned run = 0u; run < 2u; run++) {
+        duckvep_carriers_t *s = &streams[run];
+        uint32_t tx;
+        duckvep_carriers_status_t status;
+        while ((status = duckvep_carriers_finish(s, &tx)) == DUCKVEP_CARRIERS_TRANSCRIPT_READY) {
+            if (!carrier_test_drain(s, tx, expected[run][tx], base)) return THEFT_TRIAL_FAIL;
+        }
+        if (status != DUCKVEP_CARRIERS_DONE || s->transcript_count || s->call_count || s->prefix_count ||
+            s->peak_transcripts > 2u || s->peak_calls > 16u || s->peak_prefixes > 64u)
+            return THEFT_TRIAL_FAIL;
+    }
+    return THEFT_TRIAL_PASS;
+}
+
+TEST carrier_stream_matches_dense_matrix_across_batches(void) {
+    struct theft_type_info type = {.alloc = carrier_matrix_alloc, .free = carrier_matrix_free};
+    struct theft_run_config cfg = {0};
+    cfg.name = "sparse carrier paths == dense event matrix across input batches";
+    cfg.prop1 = prop_carrier_stream_matches_dense_matrix;
+    cfg.type_info[0] = &type;
+    cfg.trials = kprop_env_u64("DUCKVEP_PROP_TRIALS", KPROP_DEFAULT_TRIALS);
+    cfg.seed = (theft_seed)kprop_env_u64("DUCKVEP_PROP_SEED", KPROP_DEFAULT_SEED);
+    ASSERT_EQ(THEFT_RUN_PASS, theft_run(&cfg));
     PASS();
 }
 
@@ -24933,6 +25252,9 @@ int main(int argc, char **argv) {
     RUN_TEST(coding_snv_from_cds_known_cases);
     RUN_TEST(coding_snv_from_cds_matches_oracle_for_any_valid_snv);
     RUN_TEST(haplotype_edit_geometry_agrees_in_both_orders);
+    RUN_TEST(carrier_stream_lifetime_keys_and_capacity);
+    RUN_TEST(carrier_stream_reuses_slots_after_many_transcripts);
+    RUN_TEST(carrier_stream_matches_dense_matrix_across_batches);
     RUN_TEST(haplotype_partition_known_cases);
     RUN_TEST(haplotype_partition_preserves_interactions_for_any_valid_edit_set);
     RUN_TEST(haplotype_apply_and_translate_known_cases);


### PR DESCRIPTION
## Summary

Advance https://github.com/RGenomicsETL/duckhts/issues/92 with a host-neutral sparse carrier-path index and a real consumer in the existing Haplosaurus differential. This is an internal kernel prerequisite, **not** the public phased executor and does not close that issue.

- One borrowed immutable model per caller-owned workspace. Preserve sample, nullable phase set, haplotype lane and ploidy; reference paths remain implicit.
- Intern event prefixes across carriers. Drain each occupied path and its complete carrier list when sorted input passes the transcript end, then recycle only that transcript's slots. A min-heap in the existing active array makes non-expiring advances inspect only the earliest transcript; opening/closing updates O(log active) heap slots. Hash deletion does not accumulate tombstones.
- Validate all capacity/key conditions before mutation. Distinguish transcript/call/prefix exhaustion, duplicate calls, ploidy conflicts, input-order errors and output-buffer pressure.
- Keep the existing direct edit-set oracle; require its complete lane output to agree with the carrier-index consumer before comparing both against pinned Haplosaurus. Existing seeds, strata, denominators, verifier controls and conformance classifications are retained.
- Wire the translation unit through the canonical source manifest, native properties and bootstrapped R bundle. No new SQL/R API, phase policy or mutable faidx state is introduced. Root NEWS records internal development; there is no package-facing behavior change to put in R NEWS.

## Validation

- `make release -j2` and `make test_release`: passed, including SQL conformance and reader allocation-failure recovery.
- Full native properties with `DUCKVEP_PROP_TRIALS=100000 DUCKVEP_PROP_SEED=20260906`: 220 tests, 384,236 assertions, zero failures/skips.
- AddressSanitizer and UndefinedBehaviorSanitizer carrier tests: four tests and 74,533 assertions each, passed.
- New dense-matrix property checks complete event lists and carrier keys across every carrier-row batch split, with two interleaved distinct models. A deterministic lifetime test reuses one transcript slot, eight call slots and one prefix slot across 1,000 transcript closures.
- Expiry-frontier regression: 256 model transcripts in permuted opening order, 64 simultaneous occupied slots, tied expiration times, interleaved expiry/opening and hash-slot reuse. Compare every emitted path/carrier and the heap root against a separate dense live set.
- R bootstrap followed by `THREADS=4 make test` (tarball build/install): all 4,472 results passed.
- Haplosaurus differential, 1,000 transcripts each: seed 173 has 2,764 records / 16,584 allele slots; seed 20260906 has 2,802 records / 16,812 allele slots. Each campaign checks 6,000 lanes and 22,000 comparisons, with zero mismatches and all seven deliberately corrupted verifier observations rejected separately.
- `git diff --check`: passed.

This does not certify genomic projection, genotype decoding, strict phase interpretation, compound SO/HGVS, structural composition, arbitrary-ploidy Haplosaurus compatibility or DuckDB query lifecycle. The planned phased transition remains `not_implemented`.

## Performance

No checked-in benchmark currently exercises the new carrier index. The nearest rendered baseline is [`benchmarks/duckvep_throughput.md`](https://github.com/RGenomicsETL/duckhts/blob/be8139bd2c3bb76c191ce06c9b4580192502778f/benchmarks/duckvep_throughput.md): source revision `fc67aef3fffb9bed2b040562ba4e9b9e5bc0d65f`, `fixture_one_transcript_sorted`, rich independent-event output, one transcript/two exons, 10,000,000 input variants → 10,000,000 consequence rows, one DuckDB worker, three measured passes, median **3.333 s** on an Intel i5-13500 (affinity 0–19). Its preceding identical recorded workload at `41e84614d12ae5166652804c0ceb1f662db8530f` measured **3.321 s**.

Those measurements predate this index and do not call it; they are not a current-head performance comparison or evidence of no regression. The differential's new `carrier_metrics.csv` is work accounting only. Missing measurements are carrier-index throughput/active-memory high-water marks and the complete ordered versus sort-included phased pipeline, with projected edits, active carriers, unique prefixes, completed paths, translated bases and output denominators. No speed or cohort-memory claim is made here.
