### PR TITLE
Validate haplotypes from decoded genotype reader output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -571,9 +571,9 @@ test-duckvep-differential: release
 		--extension build/release/duckhts.duckdb_extension \
 		--sample-per-shape 0 --hgvs
 
-# Independent Haplosaurus oracle for the existing native edit-set mechanics.
-# No DuckDB build or public phased-execution claim is involved.
-test-duckvep-haplotype-mechanics:
+# Independent Haplosaurus oracle for native edit-set mechanics, including calls
+# decoded by the extension. This does not certify public phased execution.
+test-duckvep-haplotype-mechanics: release
 	VEP_PREFIX=$(VEP_PREFIX) Rscript test/duckvep/conformance/haplotype_differential.R \
 		$(DUCKVEP_HAPLOTYPE_ARGS)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # DuckHTS Extension News
 
 # duckhts 1.5.1.9000
+- connect the Haplosaurus differential to actual `read_geno()` calls while
+  retaining both native comparison paths, the original verifier controls and
+  source-bound build receipts; this is not a public phased-executor certificate
+
 - add record-major `read_geno()` with typed arbitrary-ploidy GT/PS calls,
   per-allele phase flags and sparse non-reference calls. Share HTSlib sample
   selection with `read_bcf()` and expose stable original-header indices through

--- a/test/duckvep/conformance/README.md
+++ b/test/duckvep/conformance/README.md
@@ -513,7 +513,8 @@ edit grouping, same-codon interactions, open frameshifts, and restored frameshif
 Haplosaurus differential belongs with the public phased input surface rather than being
 faked in this runner.
 
-`make test-duckvep-haplotype-mechanics` runs the narrower executable prerequisite:
+`make test-duckvep-haplotype-mechanics` builds the release extension and runs the
+narrower executable prerequisite:
 the existing pure-C edit application/translation helpers against the pinned Haplosaurus
 parser, genomic-to-CDS mapper and transcript container. It generates two-exon transcripts
 on both strands, ordinary genomic VCF records, cis/trans diploid carriers and shared

--- a/test/duckvep/conformance/README.md
+++ b/test/duckvep/conformance/README.md
@@ -529,10 +529,11 @@ The campaign also loads the built extension (`--extension`) and reads the genera
 VCF through `read_geno()` and `read_bcf_samples()`. This third path derives allele
 slots, sample identity and variant alleles from decoded calls, then runs the same
 native projector/carrier/rebuild pipeline. Both generator-fed paths remain separate
-checks, and the existing Haplosaurus verifier controls are unchanged. Four additional
+checks, and the existing Haplosaurus verifier controls are unchanged. Five additional
 routing controls require valid changed allele slots/ALT to change the haplotype and
-missing/duplicate calls to fail. The complete typed calls, metrics and controls are
-retained with the extension's SHA-256. Supplying `--extension-receipt` validates the
+missing/duplicate calls or a different model chromosome to fail. The complete typed
+calls, metrics and controls are retained with the extension's SHA-256. Supplying
+`--extension-receipt` validates the
 existing clean-revision release-build receipt; runs without one are explicitly
 `diagnostic_unbound`, not source-bound release evidence.
 
@@ -555,7 +556,8 @@ Seven deliberate corruptions exercise each comparison field; their rejection cou
 are reported separately from the real engine comparisons.
 
 This is **not** a public phased-executor certificate: the R harness materializes
-decoded calls, and it does not test native DuckDB carrier streaming, strict phase/PS interpretation, compound SO/HGVS, structural
+decoded calls, and it does not test native DuckDB carrier streaming, strict phase/PS
+interpretation, compound SO/HGVS, structural
 composition or arbitrary ploidy. Haplosaurus exposes sequence differences and frame
 flags, not a compound SO/HGVS oracle. Its offline container also defaults to two lanes
 without inferring VCF ploidy; that behavior must not silently define DuckVEP's ploidy

--- a/test/duckvep/conformance/README.md
+++ b/test/duckvep/conformance/README.md
@@ -529,9 +529,10 @@ The campaign also loads the built extension (`--extension`) and reads the genera
 VCF through `read_geno()` and `read_bcf_samples()`. This third path derives allele
 slots, sample identity and variant alleles from decoded calls, then runs the same
 native projector/carrier/rebuild pipeline. Both generator-fed paths remain separate
-checks, and the existing Haplosaurus verifier controls are unchanged. Five additional
+checks, and the existing Haplosaurus verifier controls are unchanged. Six additional
 routing controls require valid changed allele slots/ALT to change the haplotype and
-missing/duplicate calls or a different model chromosome to fail. The complete typed
+missing/duplicate calls, a different model chromosome or reversed record order to fail.
+The genotype path retains reader ordinals instead of sorting incorrect input. The complete typed
 calls, metrics and controls are retained with the extension's SHA-256. Supplying
 `--extension-receipt` validates the
 existing clean-revision release-build receipt; runs without one are explicitly

--- a/test/duckvep/conformance/README.md
+++ b/test/duckvep/conformance/README.md
@@ -525,6 +525,17 @@ every CDS contributor, per-sample counts and total carrier counts. For a larger 
 make test-duckvep-haplotype-mechanics DUCKVEP_HAPLOTYPE_ARGS="--cases 1000 --seed 173"
 ```
 
+The campaign also loads the built extension (`--extension`) and reads the generated
+VCF through `read_geno()` and `read_bcf_samples()`. This third path derives allele
+slots, sample identity and variant alleles from decoded calls, then runs the same
+native projector/carrier/rebuild pipeline. Both generator-fed paths remain separate
+checks, and the existing Haplosaurus verifier controls are unchanged. Four additional
+routing controls require valid changed allele slots/ALT to change the haplotype and
+missing/duplicate calls to fail. The complete typed calls, metrics and controls are
+retained with the extension's SHA-256. Supplying `--extension-receipt` validates the
+existing clean-revision release-build receipt; runs without one are explicitly
+`diagnostic_unbound`, not source-bound release evidence.
+
 The direct-mutation oracle receives the generated original-CDS edit coordinates.
 The separate carrier bridge receives genomic VCF alleles, transcript-ranked exons
 and the borrowed reference CDS, but no projected edit coordinates. It uses the existing
@@ -543,8 +554,8 @@ release conformance histories or the `not_implemented` phased transition.
 Seven deliberate corruptions exercise each comparison field; their rejection counts
 are reported separately from the real engine comparisons.
 
-This is **not** a public phased-executor certificate: it does not test DuckDB carrier
-streaming, strict phase/PS interpretation, compound SO/HGVS, structural
+This is **not** a public phased-executor certificate: the R harness materializes
+decoded calls, and it does not test native DuckDB carrier streaming, strict phase/PS interpretation, compound SO/HGVS, structural
 composition or arbitrary ploidy. Haplosaurus exposes sequence differences and frame
 flags, not a compound SO/HGVS oracle. Its offline container also defaults to two lanes
 without inferring VCF ploidy; that behavior must not silently define DuckVEP's ploidy

--- a/test/duckvep/conformance/haplotype_differential.R
+++ b/test/duckvep/conformance/haplotype_differential.R
@@ -337,6 +337,7 @@ main <- function() {
     vcf[[i]] <- variants$row[order(variants$pos)]
     cases[[i]] <- list(
       transcript = transcript,
+      chrom = chrom,
       shape = shape,
       strand = strand,
       cds = cds,
@@ -485,6 +486,7 @@ main <- function() {
       # Validate the declared subset, never repair an omitted/duplicate call.
       stopifnot(nrow(calls) == 3L * n,
                 setequal(calls$ID, edits$id),
+                all(calls$CHROM == case$chrom),
                 all(lengths(calls$ALT) == 1L),
                 all(lengths(calls$alleles) == 2L),
                 all(vapply(calls$phase_before, identical, TRUE, c(TRUE, TRUE))),
@@ -705,7 +707,7 @@ main <- function() {
   # missing/duplicate calls must not be replaced by generator assignments.
   witness <- cases[[1L]]
   original_calls <- do.call(rbind, calls_by_id[witness$edits$id])
-  routing_controls <- data.frame(field = c("allele_slot", "alternate", "missing_call", "duplicate_call"),
+  routing_controls <- data.frame(field = c("allele_slot", "alternate", "missing_call", "duplicate_call", "chromosome"),
                                   rejected = FALSE)
   for (i in seq_len(nrow(routing_controls))) {
     mutant <- original_calls
@@ -717,14 +719,15 @@ main <- function() {
         mutant$ALT[mutant$ID == mutant$ID[[1L]]] <- list(changed)
       },
       missing_call = { mutant <- mutant[-1L, ] },
-      duplicate_call = { mutant <- rbind(mutant, mutant[1L, ]) }
+      duplicate_call = { mutant <- rbind(mutant, mutant[1L, ]) },
+      chromosome = { mutant$CHROM <- "not_the_model_chromosome" }
     )
     routing_controls$rejected[i] <- if (i <= 2L) {
       !identical(stream_edits(witness, mutant)$paths, native[[1L]])
     } else tryCatch({
       stream_edits(witness, mutant)
       FALSE
-    }, error = function(e) grepl("nrow\\(calls\\)|anyDuplicated\\(key\\)", conditionMessage(e)))
+    }, error = function(e) grepl("nrow\\(calls\\)|anyDuplicated\\(key\\)|calls\\$CHROM", conditionMessage(e)))
   }
   write.csv(routing_controls, file.path(out, "genotype_routing_controls.csv"), row.names = FALSE)
   write.csv(failures, file.path(out, "failures.csv"), row.names = FALSE)

--- a/test/duckvep/conformance/haplotype_differential.R
+++ b/test/duckvep/conformance/haplotype_differential.R
@@ -1,15 +1,18 @@
 #!/usr/bin/env Rscript
 # Executable Haplosaurus comparison for the existing edit-set mechanics.
 # Direct edit-set mutation uses CDS coordinates; the carrier pipeline projects
-# genomic VCF alleles through ranked exons, and Haplosaurus independently parses
-# VCF/GFF. This does not certify SQL grouping, strict phase, compound SO/HGVS,
-# or arbitrary-ploidy compatibility.
+# genomic VCF alleles through ranked exons. A separate read_geno path obtains
+# alleles and carriers from that same VCF; Haplosaurus independently parses
+# VCF/GFF. This does not certify a public phased SQL executor, strict phase,
+# compound SO/HGVS, or arbitrary-ploidy compatibility.
 
 main <- function() {
   opt <- optparse::parse_args(optparse::OptionParser(
     option_list = list(
       optparse::make_option("--cases", type = "integer", default = 128L),
       optparse::make_option("--seed", type = "integer", default = 173L),
+      optparse::make_option("--extension", default = "build/release/duckhts.duckdb_extension"),
+      optparse::make_option("--extension-receipt", dest = "extension_receipt", default = NULL),
       optparse::make_option(
         "--vep-prefix",
         dest = "vep_prefix",
@@ -37,6 +40,16 @@ main <- function() {
     stdout = TRUE
   ))
   source(file.path(root, "scripts/duckvep_evidence.R"), local = TRUE)
+  source_revision <- duckvep_evidence_revision(root)
+  extension <- normalizePath(opt$extension, mustWork = TRUE)
+  extension_sha256 <- duckvep_evidence_sha256(extension)
+  build_binding <- "diagnostic_unbound"
+  if (!is.null(opt$extension_receipt)) {
+    duckvep_evidence_assert_checkout(root, source_revision)
+    build_binding <- duckvep_evidence_read_extension_receipt(
+      opt$extension_receipt, root, extension, source_revision
+    )$binding
+  }
   results <- file.path(root, "test/duckvep/conformance/results")
   dir.create(results, showWarnings = FALSE)
   out <- tempfile(paste0("haplotype_seed", opt$seed, "_"), tmpdir = results)
@@ -349,6 +362,27 @@ main <- function() {
     file.path(out, "carriers.vcf")
   )
   saveRDS(list(seed = opt$seed, cases = cases), file.path(out, "inputs.rds"))
+  # Read the actual serialized input, not the generator's lane assignments.
+  # Keep the whole typed call relation as evidence; no GT-string round trip.
+  con <- DBI::dbConnect(duckdb::duckdb(config = list(allow_unsigned_extensions = "true")))
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  DBI::dbExecute(con, paste("LOAD", DBI::dbQuoteString(con, extension)))
+  DBI::dbExecute(con, "SET threads=1")
+  input_path <- DBI::dbQuoteString(con, file.path(out, "carriers.vcf"))
+  catalog <- DBI::dbGetQuery(con, paste0(
+    "SELECT * FROM read_bcf_samples(", input_path, ") ORDER BY sample_index"
+  ))
+  stopifnot(identical(catalog$sample_name, c("cis", "trans", "shared")),
+            identical(as.numeric(catalog$sample_index), as.numeric(0:2)))
+  typed_calls <- DBI::dbGetQuery(con, paste0(
+    "SELECT * FROM (SELECT record_index,CHROM,POS,ID,REF,ALT,unnest(calls,recursive:=true) ",
+    "FROM read_geno(", input_path, ",decode_error_policy:='error')) ORDER BY record_index,sample_index"
+  ))
+  stopifnot(nrow(typed_calls) == 3L * length(vcf),
+            length(unique(typed_calls$record_index)) == length(vcf),
+            sum(lengths(typed_calls$alleles)) == 6L * length(vcf))
+  saveRDS(list(samples = catalog, calls = typed_calls), file.path(out, "genotypes.rds"))
+  calls_by_id <- split(typed_calls, typed_calls$ID)
   stopifnot(
     system2("samtools", c("faidx", shQuote(file.path(out, "reference.fa")))) ==
       0L,
@@ -433,7 +467,7 @@ main <- function() {
       contributors = sort(edits$id)
     )
   }
-  stream_edits <- function(case) {
+  stream_edits <- function(case, calls = NULL) {
     edits <- case$edits
     n <- nrow(edits)
     exons <- case$exons[
@@ -445,6 +479,35 @@ main <- function() {
       1L + as.integer(seq_len(n) %% 2L == 0L),
       rep(1L, n)
     )
+    variants <- case$variants
+    if (!is.null(calls)) {
+      # This campaign has one biallelic ALT copy in each diploid genotype.
+      # Validate the declared subset, never repair an omitted/duplicate call.
+      stopifnot(nrow(calls) == 3L * n,
+                setequal(calls$ID, edits$id),
+                all(lengths(calls$ALT) == 1L),
+                all(lengths(calls$alleles) == 2L),
+                all(vapply(calls$phase_before, identical, TRUE, c(TRUE, TRUE))),
+                all(!is.na(calls$phase_set) & calls$phase_set == 10))
+      lane <- vapply(calls$alleles, function(gt) {
+        stopifnot(identical(sort(gt), 0:1))
+        which(gt == 1L)
+      }, 1L)
+      key <- paste(calls$ID, calls$sample_index)
+      expected_key <- paste(rep(edits$id, each = 3L), rep(0:2, n))
+      stopifnot(!anyDuplicated(key), setequal(key, expected_key))
+      calls <- calls[match(expected_key, key), ]
+      lanes <- matrix(lane[match(expected_key, key)], nrow = 3L)
+      sites <- calls[seq(1L, nrow(calls), by = 3L), ]
+      # Every sample cell must refer to the same physical site's complete data.
+      for (column in c("record_index", "CHROM", "POS", "REF", "ALT")) {
+        stopifnot(identical(unname(calls[[column]]),
+                            unname(rep(sites[[column]], each = 3L))))
+      }
+      variants <- data.frame(pos = as.integer(sites$POS), ref = sites$REF,
+                              alt = vapply(sites$ALT, `[[`, "", 1L))
+      stopifnot(!anyNA(variants$pos), all(variants$pos > 0L))
+    }
     answer <- .C(
       carrier_symbol,
       charToRaw(case$cds),
@@ -453,11 +516,11 @@ main <- function() {
       as.integer(exons$start),
       as.integer(exons$end),
       as.integer(nrow(exons)),
-      as.integer(case$variants$pos),
-      case$variants$ref,
-      case$variants$alt,
+      as.integer(variants$pos),
+      variants$ref,
+      variants$alt,
       as.integer(n),
-      as.integer(order(case$variants$pos, seq_len(n)) - 1L),
+      as.integer(order(variants$pos, seq_len(n)) - 1L),
       as.integer(lanes),
       as.integer(capacity),
       cds = raw(6L * capacity),
@@ -568,6 +631,8 @@ main <- function() {
   comparisons <- 0L
   native <- vector("list", length(cases))
   carrier_metrics <- vector("list", length(cases))
+  genotype_metrics <- vector("list", length(cases))
+  genotype_comparisons <- 0L
   names(native) <- vapply(cases, `[[`, "", "transcript")
   for (case in cases) {
     expected <- list()
@@ -597,6 +662,17 @@ main <- function() {
     native[[case$transcript]] <- streamed$paths
     carrier_metrics[[match(case$transcript, names(native))]] <- streamed$metrics
     checks <- compare_haplotypes(streamed$paths, observed[[case$transcript]])
+    calls <- do.call(rbind, calls_by_id[case$edits$id])
+    decoded <- stream_edits(case, calls)
+    if (!identical(expected, decoded$paths)) {
+      saveRDS(list(input = case, calls = calls, direct = expected, decoded = decoded),
+              file.path(out, "genotype_failure.rds"))
+      stop("decoded genotypes disagree with direct edit sets for ", case$transcript)
+    }
+    genotype_metrics[[match(case$transcript, names(native))]] <- decoded$metrics
+    genotype_checks <- compare_haplotypes(decoded$paths, observed[[case$transcript]])
+    genotype_comparisons <- genotype_comparisons + length(genotype_checks)
+    stopifnot(identical(genotype_checks, checks))
     comparisons <- comparisons + length(checks)
     if (any(!checks)) {
       failures[[length(failures) + 1L]] <- data.frame(
@@ -623,6 +699,34 @@ main <- function() {
     file.path(out, "carrier_metrics.csv"),
     row.names = FALSE
   )
+  write.csv(do.call(rbind, genotype_metrics), file.path(out, "genotype_metrics.csv"), row.names = FALSE)
+  # Routing controls are additional to the seven unchanged Haplosaurus-output
+  # corruptions below. Valid changed GT/ALT must change the produced haplotype;
+  # missing/duplicate calls must not be replaced by generator assignments.
+  witness <- cases[[1L]]
+  original_calls <- do.call(rbind, calls_by_id[witness$edits$id])
+  routing_controls <- data.frame(field = c("allele_slot", "alternate", "missing_call", "duplicate_call"),
+                                  rejected = FALSE)
+  for (i in seq_len(nrow(routing_controls))) {
+    mutant <- original_calls
+    switch(routing_controls$field[i],
+      allele_slot = { mutant$alleles[[1L]] <- rev(mutant$alleles[[1L]]) },
+      alternate = {
+        changed <- setdiff(c("A", "C", "G", "T"),
+                          c(mutant$REF[[1L]], mutant$ALT[[1L]]))[[1L]]
+        mutant$ALT[mutant$ID == mutant$ID[[1L]]] <- list(changed)
+      },
+      missing_call = { mutant <- mutant[-1L, ] },
+      duplicate_call = { mutant <- rbind(mutant, mutant[1L, ]) }
+    )
+    routing_controls$rejected[i] <- if (i <= 2L) {
+      !identical(stream_edits(witness, mutant)$paths, native[[1L]])
+    } else tryCatch({
+      stream_edits(witness, mutant)
+      FALSE
+    }, error = function(e) grepl("nrow\\(calls\\)|anyDuplicated\\(key\\)", conditionMessage(e)))
+  }
+  write.csv(routing_controls, file.path(out, "genotype_routing_controls.csv"), row.names = FALSE)
   write.csv(failures, file.path(out, "failures.csv"), row.names = FALSE)
   # Exercise every comparison axis with a deliberate corruption. These seven
   # verifier controls are separate from the engine-comparison denominators.
@@ -682,8 +786,10 @@ main <- function() {
     input_allele_slots = 6L * length(vcf),
     haplotype_lanes = 6L * length(cases),
     comparisons = comparisons,
+    genotype_comparisons = genotype_comparisons,
     failures = nrow(failures),
-    verifier_controls_rejected = sum(controls$rejected)
+    verifier_controls_rejected = sum(controls$rejected),
+    genotype_routing_controls_rejected = sum(routing_controls$rejected)
   )
   write.csv(summary, file.path(out, "summary.csv"), row.names = FALSE)
   identities <- c(
@@ -718,6 +824,9 @@ main <- function() {
         "inputs.rds",
         "native.rds",
         "carrier_metrics.csv",
+        "genotypes.rds",
+        "genotype_metrics.csv",
+        "genotype_routing_controls.csv",
         "oracle.jsonl",
         "summary.csv",
         "failures.csv",
@@ -725,13 +834,19 @@ main <- function() {
         "environment.txt"
       )
     ),
-    shared
+    shared,
+    extension,
+    opt$extension_receipt
   )
+  stopifnot(identical(duckvep_evidence_sha256(extension), extension_sha256))
+  stopifnot(identical(duckvep_evidence_revision(root), source_revision))
+  if (!is.null(opt$extension_receipt)) duckvep_evidence_assert_checkout(root, source_revision)
   hashes <- vapply(identities, duckvep_evidence_sha256, "")
   jsonlite::write_json(
     list(
-      scope = "diploid_genomic_projection_carrier_prefix_and_edit_mechanics_not_public_phased_execution",
-      source_revision = system2("git", c("rev-parse", "HEAD"), stdout = TRUE),
+      scope = "diploid_genotypes_genomic_projection_carrier_prefix_and_edit_mechanics_not_public_phased_execution",
+      source_revision = source_revision,
+      extension_build_binding = build_binding,
       dirty_worktree = length(system2(
         "git",
         c("status", "--porcelain"),
@@ -750,6 +865,9 @@ main <- function() {
   print(summary, row.names = FALSE)
   if (!all(controls$rejected)) {
     stop("Haplosaurus comparison controls failed; inspect ", out, call. = FALSE)
+  }
+  if (!all(routing_controls$rejected)) {
+    stop("Genotype routing controls failed; inspect ", out, call. = FALSE)
   }
   if (nrow(failures)) {
     stop(

--- a/test/duckvep/conformance/haplotype_differential.R
+++ b/test/duckvep/conformance/haplotype_differential.R
@@ -468,7 +468,7 @@ main <- function() {
       contributors = sort(edits$id)
     )
   }
-  stream_edits <- function(case, calls = NULL) {
+  stream_edits <- function(case, calls = NULL, failure_file = "carrier_failure.rds") {
     edits <- case$edits
     n <- nrow(edits)
     exons <- case$exons[
@@ -481,6 +481,7 @@ main <- function() {
       rep(1L, n)
     )
     variants <- case$variants
+    event_order <- order(variants$pos, seq_len(n))
     if (!is.null(calls)) {
       # This campaign has one biallelic ALT copy in each diploid genotype.
       # Validate the declared subset, never repair an omitted/duplicate call.
@@ -509,6 +510,8 @@ main <- function() {
       variants <- data.frame(pos = as.integer(sites$POS), ref = sites$REF,
                               alt = vapply(sites$ALT, `[[`, "", 1L))
       stopifnot(!anyNA(variants$pos), all(variants$pos > 0L))
+      # Preserve the reader's observed order; do not silently sort bad input.
+      event_order <- order(sites$record_index)
     }
     answer <- .C(
       carrier_symbol,
@@ -522,7 +525,7 @@ main <- function() {
       variants$ref,
       variants$alt,
       as.integer(n),
-      as.integer(order(variants$pos, seq_len(n)) - 1L),
+      as.integer(event_order - 1L),
       as.integer(lanes),
       as.integer(capacity),
       cds = raw(6L * capacity),
@@ -538,7 +541,7 @@ main <- function() {
     if (answer$status != 0L) {
       saveRDS(
         list(input = case, output = answer),
-        file.path(out, "carrier_failure.rds")
+        file.path(out, failure_file)
       )
       stop("carrier index failed for ", case$transcript, ": ", answer$status)
     }
@@ -707,7 +710,7 @@ main <- function() {
   # missing/duplicate calls must not be replaced by generator assignments.
   witness <- cases[[1L]]
   original_calls <- do.call(rbind, calls_by_id[witness$edits$id])
-  routing_controls <- data.frame(field = c("allele_slot", "alternate", "missing_call", "duplicate_call", "chromosome"),
+  routing_controls <- data.frame(field = c("allele_slot", "alternate", "missing_call", "duplicate_call", "chromosome", "record_order"),
                                   rejected = FALSE)
   for (i in seq_len(nrow(routing_controls))) {
     mutant <- original_calls
@@ -720,14 +723,18 @@ main <- function() {
       },
       missing_call = { mutant <- mutant[-1L, ] },
       duplicate_call = { mutant <- rbind(mutant, mutant[1L, ]) },
-      chromosome = { mutant$CHROM <- "not_the_model_chromosome" }
+      chromosome = { mutant$CHROM <- "not_the_model_chromosome" },
+      record_order = { mutant$record_index <- max(mutant$record_index) - mutant$record_index }
     )
     routing_controls$rejected[i] <- if (i <= 2L) {
       !identical(stream_edits(witness, mutant)$paths, native[[1L]])
     } else tryCatch({
-      stream_edits(witness, mutant)
+      stream_edits(witness, mutant,
+                   failure_file = paste0("genotype_control_", routing_controls$field[i], ".rds"))
       FALSE
-    }, error = function(e) grepl("nrow\\(calls\\)|anyDuplicated\\(key\\)|calls\\$CHROM", conditionMessage(e)))
+    }, error = function(e) grepl(
+      "nrow\\(calls\\)|anyDuplicated\\(key\\)|calls\\$CHROM|carrier index failed .*: 104$",
+      conditionMessage(e)))
   }
   write.csv(routing_controls, file.path(out, "genotype_routing_controls.csv"), row.names = FALSE)
   write.csv(failures, file.path(out, "failures.csv"), row.names = FALSE)


### PR DESCRIPTION
## Summary

Progress toward https://github.com/RGenomicsETL/duckhts/issues/92 and https://github.com/RGenomicsETL/duckhts/issues/174; neither issue is closed by this change.

- Add a third Haplosaurus differential path: generated VCF -> actual `read_geno()` / `read_bcf_samples()` -> typed sample/allele slots and variant geometry -> existing native projector/carrier/rebuild kernels. Preserve both generator-fed native paths as independent comparisons.
- Preserve the reader's observed record order. Validate source/model chromosome agreement, complete sample membership, actual GT/PS values and repeated site fields. Do not repair missing/duplicate calls or sort incorrect input before the native order check.
- Retain the original seven Haplosaurus output-corruption controls unchanged. Add six routing controls: valid changed allele slots/ALT must change output; missing/duplicate calls, wrong chromosomes and reversed input order must fail. An unexpected error in a valid mutation is not counted as a successful control.
- Retain the full typed input and routing results, hash the loaded extension, and optionally verify the existing clean-revision release-build receipt. Unbound runs are labelled diagnostic. No new receipt authority or release-conformance acceptance category is introduced.

The generator, seeds, trial counts, biological comparison fields, native kernels and existing verifier acceptance rules are unchanged. This is R conformance tooling, not a public phased SQL executor. The R harness materializes calls; strict phase/PS interpretation, arbitrary ploidy, compound SO/HGVS, structural composition and bounded public streaming remain open. No production source or R package behavior changes; NEWS is repo-only accordingly.

## Validation

Smoke campaigns passed both seeds, retaining 220 original and 220 decoded-genotype comparisons per seed. The seed-173 generated VCF/reference bytes match the pre-change smoke campaign. Following Codex review, the Make target now builds its required release extension; a smoke run with the extension artifact initially absent successfully rebuilt it. Full campaigns at `39c5bb87f574cc369cd207c0581b400d9b8d7b58` use clean-checkout `htslib_distclean_make_release` receipts:

| Seed | Transcripts | Input records | Allele slots | Haplotype lanes | Original comparisons | Genotype comparisons | Mismatches | Original / routing controls rejected |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 173 | 1,000 | 2,764 | 16,584 | 6,000 | 22,000 | 22,000 | 0 | 7 / 6 |
| 20260906 | 1,000 | 2,802 | 16,812 | 6,000 | 22,000 | 22,000 | 0 | 7 / 6 |

Both campaigns retain complete input/output artifacts, metrics, controls and SHA-256 receipts under the ignored conformance results directory. No release conformance history or `not_implemented` phased-executor classification is changed.

`git diff --check` passes. Production `src` tree remains `74bd979a13e3272dd3f475437fd7235341f8cefa`.

## Performance

No checked-in benchmark exercises this new genotype-to-Haplosaurus verification path, and its end-to-end time/memory measurement remains missing. This PR changes diagnostic R plumbing, not a measured production hot path.

The nearest rendered baseline is [benchmarks/benchmark_genotypes.md](https://github.com/RGenomicsETL/duckhts/blob/main/benchmarks/benchmark_genotypes.md), source `48ac22cbd06a1dd19ed425489d9b1e883209ada6`, with the same production source tree. Its registered HPRC v2.0 chr22 cohort has 14,365 input records, 232 samples, 3,332,680 calls and 6,665,360 allele slots; BCF input is 6,179,639 bytes. Full `read_geno` materialization produces 14,365 rows; downstream expansion produces 614,611 carrier rows. With one DuckDB/scan worker, zero HTSlib decompression workers, CPU affinity 2 and three fresh-process repetitions, recorded BCF medians are 0.938 s for full materialization and 0.901 s for carrier expansion. Those prior measurements do not establish performance of this R verification path or the future public phased executor, nor PS decoding throughput (the benchmark source is GT-only).

## Review / merge gate

Current-head Codex review with no major issues and all CI checks are required before merge.
